### PR TITLE
Feature/parsing av model dcat ap no mandatory

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ from nox.sessions import Session
 package = "modelldcatnotordf"
 locations = "src", "tests", "noxfile.py", "docs/conf.py"
 nox.options.stop_on_first_error = True
-nox.options.sessions = "black", "lint", "mypy", "pytype", "tests"
+nox.options.sessions = "lint", "mypy", "pytype", "tests"
 
 
 def install_with_constraints(session: Session, *args: str, **kwargs: Any) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ from nox.sessions import Session
 package = "modelldcatnotordf"
 locations = "src", "tests", "noxfile.py", "docs/conf.py"
 nox.options.stop_on_first_error = True
-nox.options.sessions = "lint", "mypy", "pytype", "tests"
+nox.options.sessions = "black", "lint", "mypy", "pytype", "tests"
 
 
 def install_with_constraints(session: Session, *args: str, **kwargs: Any) -> None:

--- a/src/modelldcatnotordf/agent.py
+++ b/src/modelldcatnotordf/agent.py
@@ -1,0 +1,72 @@
+"""Agent module for mapping a model to rdf.
+
+This module contains methods for mapping a agent object to rdf
+for use in the modelldcat-ap-no specification._
+
+Refer to sub-class for typical usage examples.
+"""
+from typing import Optional
+
+from datacatalogtordf import URI
+from rdflib import BNode, Graph, Literal, Namespace, RDF, URIRef
+
+FOAF = Namespace("http://xmlns.com/foaf/0.1/")
+
+
+class Agent(BNode):
+    """A class representing a foaf:Agent."""
+
+    __slots__ = ("_g", "_identifier", "_name", "_type")
+
+    _g: Graph
+    _identifier: URI
+    _name: str
+
+    def __init__(self) -> None:
+        """Inits Agent object with default values."""
+        self._type = FOAF.Agent
+
+    @property
+    def identifier(self) -> str:
+        """Get/set for identifier."""
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier: str) -> None:
+        self._identifier = URI(identifier)
+
+    @property
+    def name(self) -> str:
+        """Get/set for name."""
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
+
+    def to_rdf(
+        self: BNode, format: str = "turtle", encoding: Optional[str] = "utf-8"
+    ) -> str:
+        """Maps the agent to rdf.
+
+        Args:
+            format: a valid format. Default: turtle
+            encoding: the encoding to serialize into
+
+        Returns:
+            a rdf serialization as a string according to format.
+        """
+        return self._to_graph().serialize(format=format, encoding=encoding)
+
+    def _to_graph(self: BNode) -> Graph:
+        self._g = Graph()
+        self._g.bind("foaf", FOAF)
+
+        self._g.add((URIRef(self._identifier), RDF.type, URIRef(self._type)))
+        self._name_to_graph()
+
+        return self._g
+
+    def _name_to_graph(self: BNode) -> None:
+        if getattr(self, "name", None):
+            self._g.add((URIRef(self.identifier), FOAF.name, Literal(self._name)))

--- a/src/modelldcatnotordf/informationmodel.py
+++ b/src/modelldcatnotordf/informationmodel.py
@@ -7,8 +7,11 @@ Refer to sub-class for typical usage examples.
 """
 from typing import List, Optional
 
-from datacatalogtordf import Resource, URI
+from datacatalogtordf import Resource
 from rdflib import Graph, Literal, Namespace, RDF, URIRef
+
+from modelldcatnotordf.agent import Agent
+
 
 DCT = Namespace("http://purl.org/dc/terms/")
 DCAT = Namespace("http://www.w3.org/ns/dcat#")
@@ -25,7 +28,7 @@ class InformationModel(Resource):
     __slots__ = ("_title", "_type", "_description", "_theme", "_publisher")
 
     _title: dict
-    _publisher: URI
+    _publisher: Agent
 
     def __init__(self) -> None:
         """Inits InformationModel object with default values."""
@@ -60,13 +63,13 @@ class InformationModel(Resource):
         self._theme = value
 
     @property
-    def publisher(self: Resource) -> str:
+    def publisher(self: Resource) -> Agent:
         """Get/set for publisher."""
         return self._publisher
 
     @publisher.setter
-    def publisher(self: Resource, publisher: str) -> None:
-        self._publisher = URI(publisher)
+    def publisher(self: Resource, publisher: Agent) -> None:
+        self._publisher = publisher
 
     def to_rdf(
         self: Resource, format: str = "turtle", encoding: Optional[str] = "utf-8",
@@ -93,17 +96,10 @@ class InformationModel(Resource):
         super(InformationModel, self)._to_graph()
 
         self._g.add((URIRef(self.identifier), RDF.type, self._type))
-        self._publisher_to_graph()
 
         self._title_to_graph()
 
         return self._g
-
-    def _publisher_to_graph(self: Resource) -> None:
-        if getattr(self, "publisher", None):
-            self._g.add(
-                (URIRef(self.identifier), DCT.publisher, URIRef(self.publisher))
-            )
 
     def _title_to_graph(self: Resource) -> None:
         if getattr(self, "title", None):

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,69 @@
+"""Test cases for the foaf:agent module."""
+
+import pytest
+from rdflib import Graph
+from rdflib.compare import graph_diff, isomorphic
+
+from modelldcatnotordf.agent import Agent
+
+"""
+A test class for testing the _abstract_ class Resource.
+Using Dataset class in order to instantiate Resource.
+"""
+
+
+def test_instantiate_agent() -> None:
+    """It returns a TypeErro exception."""
+    try:
+        _ = Agent()
+    except Exception:
+        pytest.fail("Unexpected Exception ..")
+
+
+def test_to_graph_should_return_name_() -> None:
+    """It returns a agent graph isomorphic to spec."""
+    """It returns an name graph isomorphic to spec."""
+    agent = Agent()
+    agent.identifier = "http://example.com/agents/1"
+    agent.name = "Etnavn"
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+
+    <http://example.com/agents/1> a foaf:Agent ;
+            foaf:name   "Etnavn" ;
+
+    .
+    """
+    g1 = Graph().parse(data=agent.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+# ---------------------------------------------------------------------- #
+# Utils for displaying debug information
+
+
+def _dump_diff(g1: Graph, g2: Graph) -> None:
+    in_both, in_first, in_second = graph_diff(g1, g2)
+    print("\nin both:")
+    _dump_turtle(in_both)
+    print("\nin first:")
+    _dump_turtle(in_first)
+    print("\nin second:")
+    _dump_turtle(in_second)
+
+
+def _dump_turtle(g: Graph) -> None:
+    for _l in g.serialize(format="turtle").splitlines():
+        if _l:
+            print(_l.decode())

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -4,6 +4,7 @@ import pytest
 from rdflib import Graph
 from rdflib.compare import graph_diff, isomorphic
 
+from modelldcatnotordf.agent import Agent
 from modelldcatnotordf.informationmodel import InformationModel
 
 """
@@ -107,19 +108,24 @@ def test_to_graph_should_return_publisher() -> None:
     """It returns a publisher graph isomorphic to spec."""
     informationmodel = InformationModel()
     informationmodel.identifier = "http://example.com/informationmodels/1"
-    informationmodel.publisher = "http://example.com/publisher/1"
+
+    agent = Agent()
+    agent._identifier = "http://example.com/publisher/1"
+    agent._name = "Etnavn"
+
+    informationmodel.publisher = agent
 
     src = """
     @prefix dct: <http://purl.org/dc/terms/> .
     @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
     @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
     @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 
-    <http://example.com/informationmodels/1> a dcat:Resource ;
-        dct:publisher   <http://example.com/publisher/1> ;
-        .
+    <http://example.com/publisher/1> a foaf:Agent .
+    <http://example.com/publisher/1> foaf:name "Etnavn"  .
     """
-    g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
+    g1 = Graph().parse(data=informationmodel.publisher.to_rdf(), format="turtle")
     g2 = Graph().parse(data=src, format="turtle")
 
     _isomorphic = isomorphic(g1, g2)


### PR DESCRIPTION
Her kommer en liten PR igjen. Dette er det som beskriver en mandatory object property mellom modelldcatno:InformationModel og foaf:Agent, ref. UML-diagrammet. Tar dette nå også fordi jeg gjerne vil være sikker på at jeg er på rikitg vei. Publisher beskrives altså i modellen som object property mellom InformationModel og Agent. 

Ikke vær redd for å være kritiske dersom ting er feil. Det er viktig at dette gjøres på riktig måte

Se gjerne grundig over de nye testene som er lagt til. Her har et eksempel der information.publisher serialiseres og parses. Det er her jeg ønsker å være helt sikker på at dette er gjort på riktig måte.


Ref. UML:

https://user-images.githubusercontent.com/34306822/97409591-31ba8800-18fe-11eb-981f-4c8a4f39869f.png