### PR TITLE
Feature/parsing av model dcat ap no recommended 5

### DIFF
--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -162,12 +162,19 @@ class InformationModel(Resource):
 class ModelElement:
     """A class representing a modelldcatno:ModelElement."""
 
-    __slots__ = ("_type", "_g", "_title", "_identifier", "_has_property")
+    __slots__ = (
+        "_type",
+        "_g",
+        "_title",
+        "_identifier",
+        "_has_property",
+        "_dct_identifier",
+    )
 
     _g: Graph
     _title: dict
     _identifier: URI
-
+    _dct_identifier: str
     _has_property: List[ModelProperty]
 
     def __init__(self) -> None:
@@ -186,6 +193,15 @@ class ModelElement:
     @identifier.setter
     def identifier(self, identifier: str) -> None:
         self._identifier = URI(identifier)
+
+    @property
+    def dct_identifier(self) -> str:
+        """Get/set for dct_identifier."""
+        return self._dct_identifier
+
+    @dct_identifier.setter
+    def dct_identifier(self, dct_identifier: str) -> None:
+        self._dct_identifier = dct_identifier
 
     @property
     def title(self) -> dict:
@@ -224,6 +240,9 @@ class ModelElement:
         if getattr(self, "title", None):
             for key in self.title:
                 self._g.add((_self, DCT.title, Literal(self.title[key], lang=key),))
+
+        if getattr(self, "dct_identifier", None):
+            self._g.add((_self, DCT.identifier, Literal(self._dct_identifier)))
 
         return self._g
 

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -89,7 +89,7 @@ class InformationModel(Resource):
         self._publisher = publisher
 
     @property
-    def subject(self: Resource) -> URI:
+    def subject(self: Resource) -> List[str]:
         """Get/set for subject."""
         return self._subject
 

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -169,6 +169,7 @@ class ModelElement:
         "_identifier",
         "_has_property",
         "_dct_identifier",
+        "_subject",
     )
 
     _g: Graph
@@ -176,6 +177,7 @@ class ModelElement:
     _identifier: URI
     _dct_identifier: str
     _has_property: List[ModelProperty]
+    _subject: str
 
     def __init__(self) -> None:
         """Inits an object with default values."""
@@ -212,6 +214,15 @@ class ModelElement:
     def title(self, title: dict) -> None:
         self._title = title
 
+    @property
+    def subject(self) -> str:
+        """Get/set for subject."""
+        return self._subject
+
+    @subject.setter
+    def subject(self, subject: str) -> None:
+        self._subject = subject
+
     def to_rdf(self, format: str = "turtle", encoding: Optional[str] = "utf-8") -> str:
         """Maps the modelelement to rdf.
 
@@ -243,6 +254,9 @@ class ModelElement:
 
         if getattr(self, "dct_identifier", None):
             self._g.add((_self, DCT.identifier, Literal(self._dct_identifier)))
+
+        if getattr(self, "subject", None):
+            self._g.add((_self, SKOS.Concept, URIRef(self.subject)))
 
         return self._g
 

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -176,7 +176,7 @@ class ModelElement:
     _title: dict
     _identifier: URI
     _dct_identifier: str
-    _has_property: List[ModelProperty]
+    _has_property: List[Any]
     _subject: str
 
     def __init__(self) -> None:
@@ -186,6 +186,7 @@ class ModelElement:
         self._g.bind("modelldcatno", MODELLDCATNO)
         self._g.bind("dct", DCT)
         self._g.bind("dcat", DCAT)
+        self._has_property = []
 
     @property
     def identifier(self) -> str:
@@ -223,6 +224,11 @@ class ModelElement:
     def subject(self, subject: str) -> None:
         self._subject = subject
 
+    @property
+    def has_property(self) -> List[Any]:
+        """Get/set for has_type."""
+        return self._has_property
+
     def to_rdf(self, format: str = "turtle", encoding: Optional[str] = "utf-8") -> str:
         """Maps the modelelement to rdf.
 
@@ -258,7 +264,24 @@ class ModelElement:
         if getattr(self, "subject", None):
             self._g.add((_self, SKOS.Concept, URIRef(self.subject)))
 
+        if getattr(self, "has_property", None):
+            self._has_property_to_graph(_self)
+
         return self._g
+
+    def _has_property_to_graph(self, _self: Any) -> None:
+        if getattr(self, "has_property", None):
+            for has_property in self._has_property:
+
+                if getattr(has_property, "identifier", None):
+                    _has_property = URIRef(has_property.identifier)
+                else:
+                    _has_property = BNode()
+
+                for _s, p, o in has_property._to_graph().triples((None, None, None)):
+                    self._g.add((_has_property, p, o))
+
+                self._g.add((_self, MODELLDCATNO.hasProperty, _has_property,))
 
 
 class ModelProperty:

--- a/tests/test_modelelement.py
+++ b/tests/test_modelelement.py
@@ -76,6 +76,33 @@ def test_to_graph_should_return_title_and_no_identifier() -> None:
     assert _isomorphic
 
 
+def test_to_graph_should_return_organizationid_as_graph() -> None:
+    """It returns a organization_id graph isomorphic to spec."""
+    modelelement = ModelElement()
+    modelelement.identifier = "http://example.com/modelelements/1"
+    modelelement.dct_identifier = "123456789"
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+    <http://example.com/modelelements/1>    a modelldcatno:ModelElement ;
+        dct:identifier "123456789";
+    .
+    """
+    g1 = Graph().parse(data=modelelement.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
 # ---------------------------------------------------------------------- #
 # Utils for displaying debug information
 

--- a/tests/test_modelelement.py
+++ b/tests/test_modelelement.py
@@ -76,8 +76,8 @@ def test_to_graph_should_return_title_and_no_identifier() -> None:
     assert _isomorphic
 
 
-def test_to_graph_should_return_organizationid_as_graph() -> None:
-    """It returns a organization_id graph isomorphic to spec."""
+def test_to_graph_should_return_dct_identifier_as_graph() -> None:
+    """It returns a dct_identifier graph isomorphic to spec."""
     modelelement = ModelElement()
     modelelement.identifier = "http://example.com/modelelements/1"
     modelelement.dct_identifier = "123456789"

--- a/tests/test_modelelement.py
+++ b/tests/test_modelelement.py
@@ -5,6 +5,8 @@ from rdflib import Graph
 from rdflib.compare import graph_diff, isomorphic
 
 from modelldcatnotordf.modelldcatno import ModelElement
+from modelldcatnotordf.modelldcatno import ModelProperty
+
 
 """
 A test class for testing the class ModelElement.
@@ -122,6 +124,128 @@ def test_to_graph_should_return_subject() -> None:
 
     .
     """
+    g1 = Graph().parse(data=modelelement.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_has_property_both_identifiers() -> None:
+    """It returns a has_property graph isomorphic to spec."""
+    modelelement = ModelElement()
+    modelelement.identifier = "http://example.com/modelelements/1"
+
+    modelproperty = ModelProperty()
+    modelproperty.identifier = "http://example.com/properties/1"
+    modelelement.has_property.append(modelproperty)
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+        <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
+        modelldcatno:hasProperty <http://example.com/properties/1> .
+
+        <http://example.com/properties/1> a modelldcatno:Property ;
+
+        .
+        """
+    g1 = Graph().parse(data=modelelement.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_has_property_bnode_modelelement_id() -> None:
+    """It returns a has_property graph isomorphic to spec."""
+    modelelement = ModelElement()
+    modelelement.identifier = "http://example.com/modelelements/1"
+
+    modelproperty = ModelProperty()
+    modelelement.has_property.append(modelproperty)
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+        <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
+            modelldcatno:hasProperty [ a modelldcatno:Property ] .
+
+        """
+    g1 = Graph().parse(data=modelelement.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_has_property_bnode_modelproperty_id() -> None:
+    """It returns a has_property graph isomorphic to spec."""
+    modelelement = ModelElement()
+
+    modelproperty = ModelProperty()
+    modelproperty.identifier = "http://example.com/properties/1"
+    modelelement.has_property.append(modelproperty)
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+        [ a modelldcatno:ModelElement ;
+            modelldcatno:hasProperty <http://example.com/properties/1>
+        ] .
+
+        <http://example.com/properties/1> a modelldcatno:Property .
+
+        """
+    g1 = Graph().parse(data=modelelement.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_has_property_blank_nodes() -> None:
+    """It returns a has_property graph isomorphic to spec."""
+    modelelement = ModelElement()
+
+    modelproperty = ModelProperty()
+    modelelement.has_property.append(modelproperty)
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+        [ a modelldcatno:ModelElement ;
+            modelldcatno:hasProperty [ a modelldcatno:Property ]
+        ] .
+        """
     g1 = Graph().parse(data=modelelement.to_rdf(), format="turtle")
     g2 = Graph().parse(data=src, format="turtle")
 

--- a/tests/test_modelelement.py
+++ b/tests/test_modelelement.py
@@ -103,6 +103,35 @@ def test_to_graph_should_return_organizationid_as_graph() -> None:
     assert _isomorphic
 
 
+def test_to_graph_should_return_subject() -> None:
+    """It returns a subject graph isomorphic to spec."""
+    modelelement = ModelElement()
+    modelelement.identifier = "http://example.com/modelelements/1"
+    modelelement.subject = "http://example.com/subjects/1"
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+    @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+    <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
+        skos:Concept <http://example.com/subjects/1> ;
+
+    .
+    """
+    g1 = Graph().parse(data=modelelement.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
 # ---------------------------------------------------------------------- #
 # Utils for displaying debug information
 


### PR DESCRIPTION
- Lagt til dct:identifier på modelldcatno:ModelElement
- Lagt til  dct:subject på modelldcatno:ModelElement
- Lagt til støtte for modelldcatno:hasProperty på ModelElement

Legg merke til at _has_property er av typen List[Any], samme som @stigbd sin models i datacatalogtordf

Dette er fordi at dersom man setter typen til List[ModelProperty] så havner man inni en slags rekursjonsbrønn selv om det ikke er noe data å rekursere på, men bare referansen til List[ModelProperty] genererer en rekursjonsbrønn i getteren til has_Property. Dette mistenker jeg (uten å være noen ekspert på Python) har å gjøre med samme type rekursive problemstilling med import av klasser i modellen som har pekere til hverandre. 


