### PR TITLE
Feature/parsing av model dcat ap no recommended + feilretting

### DIFF
--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -156,7 +156,7 @@ class InformationModel(Resource):
     def _subject_to_graph(self: InformationModel) -> None:
         if getattr(self, "subject", None):
             for subject in self._subject:
-                self._g.add((URIRef(self.identifier), DCT.Subject, URIRef(subject)))
+                self._g.add((URIRef(self.identifier), DCT.subject, URIRef(subject)))
 
     def _modelelements_to_graph(self: InformationModel) -> None:
 
@@ -285,7 +285,7 @@ class ModelElement:
             self._g.add((_self, DCT.identifier, Literal(self._dct_identifier)))
 
         if getattr(self, "subject", None):
-            self._g.add((_self, DCT.Subject, URIRef(self.subject)))
+            self._g.add((_self, DCT.subject, URIRef(self.subject)))
 
         if getattr(self, "has_property", None):
             self._has_property_to_graph(_self)
@@ -427,7 +427,7 @@ class ModelProperty:
                 self._g.add((_self, DCT.title, Literal(self.title[key], lang=key),))
 
         if getattr(self, "subject", None):
-            self._g.add((_self, DCT.Subject, URIRef(self.subject)))
+            self._g.add((_self, DCT.subject, URIRef(self.subject)))
 
         return self._g
 

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -156,7 +156,7 @@ class InformationModel(Resource):
     def _subject_to_graph(self: InformationModel) -> None:
         if getattr(self, "subject", None):
             for subject in self._subject:
-                self._g.add((URIRef(self.identifier), SKOS.Concept, URIRef(subject)))
+                self._g.add((URIRef(self.identifier), DCT.Subject, URIRef(subject)))
 
     def _modelelements_to_graph(self: InformationModel) -> None:
 
@@ -285,7 +285,7 @@ class ModelElement:
             self._g.add((_self, DCT.identifier, Literal(self._dct_identifier)))
 
         if getattr(self, "subject", None):
-            self._g.add((_self, SKOS.Concept, URIRef(self.subject)))
+            self._g.add((_self, DCT.Subject, URIRef(self.subject)))
 
         if getattr(self, "has_property", None):
             self._has_property_to_graph(_self)
@@ -427,7 +427,7 @@ class ModelProperty:
                 self._g.add((_self, DCT.title, Literal(self.title[key], lang=key),))
 
         if getattr(self, "subject", None):
-            self._g.add((_self, SKOS.Concept, URIRef(self.subject)))
+            self._g.add((_self, DCT.Subject, URIRef(self.subject)))
 
         return self._g
 

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -91,26 +91,28 @@ class InformationModel(Resource):
         self._theme = value
 
     @property
-    def publisher(self: Resource) -> Agent:
+    def publisher(self: InformationModel) -> Agent:
         """Get/set for publisher."""
         return self._publisher
 
     @publisher.setter
-    def publisher(self: Resource, publisher: Agent) -> None:
+    def publisher(self: InformationModel, publisher: Agent) -> None:
         self._publisher = publisher
 
     @property
-    def subject(self: Resource) -> List[str]:
+    def subject(self: InformationModel) -> List[str]:
         """Get/set for subject."""
         return self._subject
 
     @property
-    def modelelements(self: Resource) -> List[ModelElement]:
+    def modelelements(self: InformationModel) -> List[ModelElement]:
         """Get/set for modelelements."""
         return self._modelelements
 
     def to_rdf(
-        self: Resource, format: str = "turtle", encoding: Optional[str] = "utf-8",
+        self: InformationModel,
+        format: str = "turtle",
+        encoding: Optional[str] = "utf-8",
     ) -> str:
         """Maps the information model to rdf.
 
@@ -130,7 +132,7 @@ class InformationModel(Resource):
 
     # -
 
-    def _to_graph(self: Resource) -> Graph:
+    def _to_graph(self: InformationModel) -> Graph:
 
         super(InformationModel, self)._to_graph()
 
@@ -151,12 +153,12 @@ class InformationModel(Resource):
 
         return self._g
 
-    def _subject_to_graph(self: Resource) -> None:
+    def _subject_to_graph(self: InformationModel) -> None:
         if getattr(self, "subject", None):
             for subject in self._subject:
                 self._g.add((URIRef(self.identifier), SKOS.Concept, URIRef(subject)))
 
-    def _modelelements_to_graph(self: Resource) -> None:
+    def _modelelements_to_graph(self: InformationModel) -> None:
 
         if getattr(self, "modelelements", None):
 

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -33,12 +33,14 @@ class InformationModel(Resource):
         "_publisher",
         "_subject",
         "_modelelements",
+        "_informationmodelidentifier",
     )
 
     _title: dict
     _publisher: Agent
     _subject: List[str]
     _modelelements: List[ModelElement]
+    _informationmodelidentifier: str
 
     def __init__(self) -> None:
         """Inits InformationModel object with default values."""
@@ -46,6 +48,15 @@ class InformationModel(Resource):
         self._type = MODELLDCATNO.InformationModel
         self._subject = []
         self._modelelements = []
+
+    @property
+    def informationmodelidentifier(self) -> str:
+        """Get/set for informationmodelidentifier."""
+        return self._informationmodelidentifier
+
+    @informationmodelidentifier.setter
+    def informationmodelidentifier(self, informationmodelidentifier: str) -> None:
+        self._informationmodelidentifier = informationmodelidentifier
 
     @property
     def type(self) -> str:
@@ -128,6 +139,15 @@ class InformationModel(Resource):
         self._publisher_to_graph()
         self._subject_to_graph()
         self._modelelements_to_graph()
+
+        if getattr(self, "informationmodelidentifier", None):
+            self._g.add(
+                (
+                    URIRef(self.identifier),
+                    MODELLDCATNO.informationModelIdentifier,
+                    Literal(self._informationmodelidentifier),
+                )
+            )
 
         return self._g
 

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -172,8 +172,8 @@ def test_to_graph_should_return_subject() -> None:
     @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
     <http://example.com/informationmodels/1> a modelldcatno:InformationModel ;
-        dct:Subject <http://example.com/subjects/1> ;
-        dct:Subject <http://example.com/subjects/2> ;
+        dct:subject <http://example.com/subjects/1> ;
+        dct:subject <http://example.com/subjects/2> ;
     .
     """
     g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -282,6 +282,34 @@ def test_to_graph_should_return_modelelements_blank_node_with_properties() -> No
     assert _isomorphic
 
 
+def test_to_graph_should_return_informationmodelidentifier() -> None:
+    """It returns a information model identifier graph isomorphic to spec."""
+    informationmodel = InformationModel()
+    informationmodel.identifier = "http://example.com/informationmodels/1"
+    informationmodel.informationmodelidentifier = "8343e8b8-2e40-11eb-8192-f794be5d6ba1"
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+        <http://example.com/informationmodels/1> a modelldcatno:InformationModel ;
+            modelldcatno:informationModelIdentifier
+                "8343e8b8-2e40-11eb-8192-f794be5d6ba1" .
+
+        """
+    g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+    pass
+    assert _isomorphic
+
+
 # ---------------------------------------------------------------------- #
 # Utils for displaying debug information
 

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -169,12 +169,11 @@ def test_to_graph_should_return_subject() -> None:
     @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
     @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
     @prefix dcat: <http://www.w3.org/ns/dcat#> .
-    @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
     @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
     <http://example.com/informationmodels/1> a modelldcatno:InformationModel ;
-        skos:Concept <http://example.com/subjects/1> ;
-        skos:Concept <http://example.com/subjects/2> ;
+        dct:Subject <http://example.com/subjects/1> ;
+        dct:Subject <http://example.com/subjects/2> ;
     .
     """
     g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")

--- a/tests/test_modelelement.py
+++ b/tests/test_modelelement.py
@@ -116,11 +116,10 @@ def test_to_graph_should_return_subject() -> None:
     @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
     @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
     @prefix dcat: <http://www.w3.org/ns/dcat#> .
-    @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
     @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
     <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
-        skos:Concept <http://example.com/subjects/1> ;
+        dct:Subject <http://example.com/subjects/1> ;
 
     .
     """

--- a/tests/test_modelelement.py
+++ b/tests/test_modelelement.py
@@ -119,7 +119,7 @@ def test_to_graph_should_return_subject() -> None:
     @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
     <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
-        dct:Subject <http://example.com/subjects/1> ;
+        dct:subject <http://example.com/subjects/1> ;
 
     .
     """

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -291,7 +291,7 @@ def test_to_graph_should_return_subject() -> None:
     @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
     <http://example.com/properties/1> a modelldcatno:Property ;
-        dct:Subject <http://example.com/subjects/1> ;
+        dct:subject <http://example.com/subjects/1> ;
 
     .
     """

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -288,11 +288,10 @@ def test_to_graph_should_return_subject() -> None:
     @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
     @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
     @prefix dcat: <http://www.w3.org/ns/dcat#> .
-    @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
     @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
     <http://example.com/properties/1> a modelldcatno:Property ;
-        skos:Concept <http://example.com/subjects/1> ;
+        dct:Subject <http://example.com/subjects/1> ;
 
     .
     """


### PR DESCRIPTION
Ny feature : modelldcatno:informationModelIdentifier (internid for modellen hos de som eier modellen)

Retter også referanser til self til typen InformationModel fra dcat:Resource

Det er dessuten rettet  en annen liten feil i det som allerede er gjort.

Det dreier seg om subject som skal være en object property dct:subject, ikke skos:concept. Object property var satt til skos:Concept, men det er range som skal være skos:Concept. 

Sist vi snakket om dette så ble det bestemt at det ikke skulle implementeres noen klasse for skos:Concept i modelldcatno-parseren. Men akkurat nå kan man sette hva som helst som dct:subject. Når jeg ser på datacatalogtordf som har sammensatte typer som range, f.eks catalog har dcat:service, så er er det kun objekter av typen dcat:DataService som passer inn her. 

Så det blir et spørsmål om det skal lages støtte for de klassene som definerer range eller skal validatoren håndtere dette? Min "hunch" er at dere ønsker at validatoren skal ta seg av dette..