### PR TITLE
feat: #3 dct:LicenseDocument and dct:type

### DIFF
--- a/src/modelldcatnotordf/licensedocument.py
+++ b/src/modelldcatnotordf/licensedocument.py
@@ -1,0 +1,85 @@
+"""Module for mapping a LicenseDocument to rdf.
+
+This module contains methods for mapping to rdf
+according to the modelldcat-ap-no specification._
+
+Refer to sub-class for typical usage examples.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from concepttordf import Concept
+from datacatalogtordf import URI
+from rdflib import BNode, Graph, Namespace, RDF, URIRef
+
+DCT = Namespace("http://purl.org/dc/terms/")
+
+
+class LicenseDocument:
+    """A class representing a dct:LicenseDocument."""
+
+    __slots__ = ("_g", "_identifier", "_type")
+
+    _g: Graph
+    _identifier: URI
+    _type: List[Concept]
+
+    def __init__(self) -> None:
+        """Inits LicenseDocument object with default values."""
+        self._type = []
+
+    @property
+    def type(self: LicenseDocument) -> List[Concept]:
+        """Get/set for type."""
+        return self._type
+
+    @property
+    def identifier(self) -> str:
+        """Get/set for identifier."""
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier: str) -> None:
+        self._identifier = URI(identifier)
+
+    def to_rdf(self, format: str = "turtle", encoding: Optional[str] = "utf-8") -> str:
+        """Maps the license document to rdf.
+
+        Args:
+            format: a valid format. Default: turtle
+            encoding: the encoding to serialize into
+
+        Returns:
+            a rdf serialization as a string according to format.
+        """
+        return self._to_graph().serialize(format=format, encoding=encoding)
+
+    def _to_graph(self) -> Graph:
+        """Returns the license document as graph.
+
+        Returns:
+            the license document graph
+        """
+        self._g = Graph()
+        self._g.bind("dct", DCT)
+
+        if getattr(self, "identifier", None):
+            _self = URIRef(self.identifier)
+        else:
+            _self = BNode()
+
+        self._g.add((_self, RDF.type, DCT.LicenseDocument))
+
+        if getattr(self, "type", None):
+
+            for type in self._type:
+
+                _type = URIRef(type.identifier)
+
+                for _s, p, o in type._to_graph().triples((None, None, None)):
+                    self._g.add((_type, p, o))
+
+                self._g.add((_self, DCT.type, _type,))
+
+        return self._g

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -13,6 +13,8 @@ from concepttordf import Concept
 from datacatalogtordf import Agent, Resource, URI
 from rdflib import BNode, Graph, Literal, Namespace, RDF, URIRef
 
+from modelldcatnotordf.licensedocument import LicenseDocument
+
 DCT = Namespace("http://purl.org/dc/terms/")
 DCAT = Namespace("http://www.w3.org/ns/dcat#")
 ODRL = Namespace("http://www.w3.org/ns/odrl/2/")
@@ -35,6 +37,7 @@ class InformationModel(Resource):
         "_subject",
         "_modelelements",
         "_informationmodelidentifier",
+        "_licensedocument",
     )
 
     _title: dict
@@ -42,6 +45,7 @@ class InformationModel(Resource):
     _subject: List[Concept]
     _modelelements: List[ModelElement]
     _informationmodelidentifier: str
+    _licensedocument: LicenseDocument
 
     def __init__(self) -> None:
         """Inits InformationModel object with default values."""
@@ -63,6 +67,15 @@ class InformationModel(Resource):
     def type(self) -> str:
         """Get for type."""
         return self._type
+
+    @property
+    def licensedocument(self) -> LicenseDocument:
+        """Get/set for license."""
+        return self._licensedocument
+
+    @licensedocument.setter
+    def licensedocument(self, licensedocument: LicenseDocument) -> None:
+        self._licensedocument = licensedocument
 
     @property
     def title(self) -> dict:
@@ -142,6 +155,7 @@ class InformationModel(Resource):
         self._publisher_to_graph()
         self._subject_to_graph()
         self._modelelements_to_graph()
+        self._licensedocument_to_graph()
 
         if getattr(self, "informationmodelidentifier", None):
             self._g.add(
@@ -187,6 +201,23 @@ class InformationModel(Resource):
                         _modelelement,
                     )
                 )
+
+    def _licensedocument_to_graph(self: InformationModel) -> None:
+
+        if getattr(self, "licensedocument", None):
+
+            if getattr(self.licensedocument, "identifier", None):
+                _licensedocument = URIRef(self.licensedocument.identifier)
+
+            else:
+                _licensedocument = BNode()
+
+            for _s, p, o in self.licensedocument._to_graph().triples(
+                (None, None, None)
+            ):
+                self._g.add((_licensedocument, p, o))
+
+            self._g.add((URIRef(self.identifier), DCT.license, _licensedocument))
 
 
 class ModelElement:

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -5,6 +5,7 @@ import pytest
 from rdflib import Graph, Namespace
 from rdflib.compare import graph_diff, isomorphic
 
+from modelldcatnotordf.licensedocument import LicenseDocument
 from modelldcatnotordf.modelldcatno import InformationModel
 from modelldcatnotordf.modelldcatno import ModelElement
 
@@ -321,6 +322,119 @@ def test_to_graph_should_return_informationmodelidentifier() -> None:
     if not _isomorphic:
         _dump_diff(g1, g2)
     pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_licensedocument() -> None:
+    """It returns a license document graph isomorphic to spec."""
+    licensedocument = LicenseDocument()
+    licensedocument.identifier = "http://example.com/licensedocuments/1"
+
+    informationmodel = InformationModel()
+    informationmodel.identifier = "https://example.com/informationmodels/1"
+
+    informationmodel.licensedocument = licensedocument
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+        @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+        <https://example.com/informationmodels/1> a modelldcatno:InformationModel ;
+            dct:license <http://example.com/licensedocuments/1> .
+
+        <http://example.com/licensedocuments/1> a dct:LicenseDocument .
+
+        """
+
+    g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_license_document_bnode() -> None:
+    """It returns a license document graph isomorphic to spec."""
+    licensedocument = LicenseDocument()
+
+    informationmodel = InformationModel()
+    informationmodel.identifier = "https://example.com/informationmodels/1"
+    informationmodel.licensedocument = licensedocument
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+        @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+        <https://example.com/informationmodels/1> a modelldcatno:InformationModel ;
+            dct:license
+                [   a dct:LicenseDocument  ]
+        .
+        """
+
+    g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_license_document_bnode_with_types() -> None:
+    """It returns an information model graph isomorphic to spec."""
+    """It returns a license document graph isomorphic to spec."""
+    """It returns a type graph isomorphic to spec."""
+
+    licensedocument = LicenseDocument()
+
+    informationmodel = InformationModel()
+    informationmodel.identifier = "https://example.com/informationmodels/1"
+    informationmodel.licensedocument = licensedocument
+
+    type1 = Concept()
+    type1.identifier = "https://example.com/types/1"
+
+    licensedocument.type.append(type1)
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+        @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+        <https://example.com/informationmodels/1> a modelldcatno:InformationModel ;
+            dct:license
+                [   a dct:LicenseDocument ;
+                        a skos:Concept ;
+                            dct:type  <https://example.com/types/1> ;
+                ]
+        .
+        """
+
+    g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
     assert _isomorphic
 
 

--- a/tests/test_licensedocument.py
+++ b/tests/test_licensedocument.py
@@ -1,0 +1,127 @@
+"""Test cases for the dct:LicenseDocument module."""
+
+from concepttordf import Concept
+import pytest
+from rdflib import Graph
+from rdflib.compare import graph_diff, isomorphic
+
+
+from modelldcatnotordf.licensedocument import LicenseDocument
+
+"""
+A test class for testing the class License Document.
+"""
+
+
+def test_instantiate_licensedocument() -> None:
+    """It returns a TypeErro exception."""
+    try:
+        _ = LicenseDocument()
+    except Exception:
+        pytest.fail("Unexpected Exception ..")
+
+
+def test_to_graph_should_return_type_and_identifier() -> None:
+    """It returns a license document graph isomorphic to spec."""
+    """It returns an type graph isomorphic to spec."""
+
+    licensedocument = LicenseDocument()
+    licensedocument.identifier = "http://example.com/licensedocuments/1"
+
+    type1 = Concept()
+    type1.identifier = "https://example.com/types/1"
+    licensedocument.type.append(type1)
+
+    type2 = Concept()
+    type2.identifier = "https://example.com/types/2"
+    licensedocument.type.append(type2)
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+        @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+        <http://example.com/licensedocuments/1>
+            a dct:LicenseDocument ;
+            dct:type <https://example.com/types/1> ;
+            dct:type <https://example.com/types/2> ;
+        .
+        <https://example.com/types/1> a skos:Concept .
+        <https://example.com/types/2> a skos:Concept .
+
+        """
+
+    g1 = Graph().parse(data=licensedocument.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_license_document_bnode_and_type() -> None:
+    """It returns a license document graph isomorphic to spec."""
+    """It returns an type graph isomorphic to spec."""
+
+    licensedocument = LicenseDocument()
+
+    type1 = Concept()
+    type1.identifier = "https://example.com/types/1"
+    licensedocument.type.append(type1)
+
+    type2 = Concept()
+    type2.identifier = "https://example.com/types/2"
+    licensedocument.type.append(type2)
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+        @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+        [   a dct:LicenseDocument ;
+            dct:type <https://example.com/types/1> ;
+            dct:type <https://example.com/types/2> ;
+        ]
+        .
+        <https://example.com/types/1> a skos:Concept .
+        <https://example.com/types/2> a skos:Concept .
+      """
+
+    g1 = Graph().parse(data=licensedocument.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+# ---------------------------------------------------------------------- #
+# Utils for displaying debug information
+
+
+def _dump_diff(g1: Graph, g2: Graph) -> None:
+    in_both, in_first, in_second = graph_diff(g1, g2)
+    print("\nin both:")
+    _dump_turtle(in_both)
+    print("\nin first:")
+    _dump_turtle(in_first)
+    print("\nin second:")
+    _dump_turtle(in_second)
+
+
+def _dump_turtle(g: Graph) -> None:
+    for _l in g.serialize(format="turtle").splitlines():
+        if _l:
+            print(_l.decode())


### PR DESCRIPTION
Dagens PR:

Dette er noe arbeid jeg har holdt på med da issuet med skos:Concept som range dukket opp. Løsningen på det var som tidligere nevnt å dra inn @stigbd sitt bibliotek concepttordf. skos:Concept er range på dct:type på dct:LicenseDocument. Dette er ting som man også kan vurdere å putte inn i datacatalogtordf etter hvert, sammen med foaf:Agent

features:
- dct:LicenseDocument 
- dct:type