### PR TITLE
feat: modelldcatno:ObjectType and modelldcatno:Role

### DIFF
--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -454,7 +454,7 @@ class ModelProperty:
 
         Args:
             type: type for identifying class. Default: MODELLDCATNO.Property
-            selfobject: an bnode or URI passed from an subclass Default: None
+            selfobject: a bnode or URI passed from an subclass Default: None
 
         Returns:
             the property graph
@@ -561,7 +561,7 @@ class Role(ModelProperty):
 
         Args:
             type: type for identifying class. Default: MODELLDCATNO.Role
-            selfobject: an bnode or URI passed from an subclass Default: None
+            selfobject: a bnode or URI passed from an subclass Default: None
 
         Returns:
             the role graph

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -298,8 +298,11 @@ class ModelElement:
         """
         return self._to_graph().serialize(format=format, encoding=encoding)
 
-    def _to_graph(self) -> Graph:
+    def _to_graph(self, type: str = MODELLDCATNO.ModelElement) -> Graph:
         """Returns the modelelement as graph.
+
+         Args:
+            type: type for identifying class. Default: MODELLDCATNO.ModelElement
 
         Returns:
             the modelelement graph
@@ -316,7 +319,7 @@ class ModelElement:
         else:
             _self = BNode()
 
-        self._g.add((_self, RDF.type, MODELLDCATNO.ModelElement))
+        self._g.add((_self, RDF.type, type))
 
         if getattr(self, "title", None):
             for key in self.title:
@@ -444,8 +447,14 @@ class ModelProperty:
         """
         return self._to_graph().serialize(format=format, encoding=encoding)
 
-    def _to_graph(self) -> Graph:
+    def _to_graph(
+        self, type: str = MODELLDCATNO.Property, selfobject: Any = None
+    ) -> Graph:
         """Returns the property as graph.
+
+        Args:
+            type: type for identifying class. Default: MODELLDCATNO.Property
+            selfobject: an bnode or URI passed from an subclass Default: None
 
         Returns:
             the property graph
@@ -456,12 +465,16 @@ class ModelProperty:
         self._g.bind("dct", DCT)
         self._g.bind("skos", SKOS)
 
-        if getattr(self, "identifier", None):
+        if selfobject:
+            _self = selfobject
+
+        elif getattr(self, "identifier", None):
             _self = URIRef(self.identifier)
+
         else:
             _self = BNode()
 
-        self._g.add((_self, RDF.type, MODELLDCATNO.Property))
+        self._g.add((_self, RDF.type, type))
 
         self._has_type_to_graph(_self)
 
@@ -500,3 +513,121 @@ class ModelProperty:
                     self._g.add((_has_type, p, o))
 
                 self._g.add((_self, MODELLDCATNO.hasType, _has_type,))
+
+
+class Role(ModelProperty):
+    """A class representing a modelldcatno:Role."""
+
+    __slots__ = (
+        "_identifier",
+        "_has_object_type",
+    )
+
+    _identifier: URI
+    _has_object_type: ObjectType
+    _g: Graph
+
+    def __init__(self) -> None:
+        """Inits an object with default values."""
+        super().__init__()
+
+    @property
+    def has_object_type(self: Role) -> ObjectType:
+        """Get/set for has_object_type."""
+        return self._has_object_type
+
+    @has_object_type.setter
+    def has_object_type(self: Role, has_object_type: Any) -> None:
+        self._has_object_type = has_object_type
+
+    def to_rdf(
+        self: Role, format: str = "turtle", encoding: Optional[str] = "utf-8"
+    ) -> str:
+        """Maps the role to rdf.
+
+        Args:
+            format: a valid format. Default: turtle
+            encoding: the encoding to serialize into
+
+        Returns:
+            a rdf serialization as a string according to format.
+        """
+        return self._to_graph().serialize(format=format, encoding=encoding)
+
+    def _to_graph(
+        self: Role, type: str = MODELLDCATNO.Role, selfobject: Any = None
+    ) -> Graph:
+        """Returns the role as graph.
+
+        Args:
+            type: type for identifying class. Default: MODELLDCATNO.Role
+            selfobject: an bnode or URI passed from an subclass Default: None
+
+        Returns:
+            the role graph
+        """
+        if getattr(self, "identifier", None):
+            _self = URIRef(self.identifier)
+        else:
+            _self = BNode()
+
+        super(Role, self)._to_graph(MODELLDCATNO.Role, _self)
+
+        self._has_object_type_to_graph(_self)
+
+        return self._g
+
+    def _has_object_type_to_graph(self, _self: Any) -> None:
+
+        if getattr(self, "has_object_type", None):
+
+            if getattr(self._has_object_type, "identifier", None):
+                _has_object_type = URIRef(self._has_object_type.identifier)
+            else:
+                _has_object_type = BNode()
+
+            for _s, p, o in self._has_object_type._to_graph().triples(
+                (None, None, None)
+            ):
+                self._g.add((_has_object_type, p, o))
+
+            self._g.add((_self, MODELLDCATNO.hasObjectType, _has_object_type))
+
+
+class ObjectType(ModelElement):
+    """A class representing a modelldcatno:ObjectType."""
+
+    _identifier: URI
+    _dct_identifier: str
+    _g: Graph
+
+    def __init__(self) -> None:
+        """Inits an object with default values."""
+        super().__init__()
+
+    def to_rdf(
+        self: ObjectType, format: str = "turtle", encoding: Optional[str] = "utf-8"
+    ) -> str:
+        """Maps the object type to rdf.
+
+        Args:
+            format: a valid format. Default: turtle
+            encoding: the encoding to serialize into
+
+        Returns:
+            a rdf serialization as a string according to format.
+        """
+        return self._to_graph().serialize(format=format, encoding=encoding)
+
+    def _to_graph(self: ObjectType, type: str = MODELLDCATNO.ObjectType) -> Graph:
+        """Returns the object type as graph.
+
+        Args:
+            type: type for identifying class. Default: MODELLDCATNO.ObjectType
+
+        Returns:
+            the object type graph
+        """
+        super(ObjectType, self)._to_graph(MODELLDCATNO.ObjectType)
+
+        return self._g

--- a/tests/test_objecttype.py
+++ b/tests/test_objecttype.py
@@ -1,0 +1,157 @@
+"""Test cases for the model object type module."""
+
+from concepttordf import Concept
+import pytest
+from rdflib import Graph
+from rdflib.compare import graph_diff, isomorphic
+
+from modelldcatnotordf.modelldcatno import ObjectType
+
+
+"""
+A test class for testing the class ObjectType.
+
+"""
+
+
+def test_instantiate_objectype() -> None:
+    """It returns a TypeErro exception."""
+    try:
+        _ = ObjectType()
+    except Exception:
+        pytest.fail("Unexpected Exception ..")
+
+
+def test_to_graph_should_return_title_and_identifier() -> None:
+    """It returns a title graph isomorphic to spec."""
+    """It returns an identifier graph isomorphic to spec."""
+
+    objectype = ObjectType()
+    objectype.identifier = "http://example.com/objectypes/1"
+    objectype.title = {"nb": "Tittel 1", "en": "Title 1"}
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+        <http://example.com/objectypes/1> a modelldcatno:ObjectType;
+                dct:title   "Title 1"@en, "Tittel 1"@nb ;
+        .
+        """
+    g1 = Graph().parse(data=objectype.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_title_and_no_identifier() -> None:
+    """It returns a title graph isomorphic to spec."""
+    objectype = ObjectType()
+    objectype.title = {"nb": "Tittel 1", "en": "Title 1"}
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+        [ a modelldcatno:ObjectType ;
+            dct:title   "Title 1"@en, "Tittel 1"@nb ;
+        ]
+        .
+        """
+    g1 = Graph().parse(data=objectype.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_dct_identifier_as_graph() -> None:
+    """It returns a dct_identifier graph isomorphic to spec."""
+    objectype = ObjectType()
+    objectype.identifier = "http://example.com/objectypes/1"
+    objectype.dct_identifier = "123456789"
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+    <http://example.com/objectypes/1>    a modelldcatno:ObjectType ;
+        dct:identifier "123456789";
+    .
+    """
+    g1 = Graph().parse(data=objectype.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_subject() -> None:
+    """It returns a subject graph isomorphic to spec."""
+    objectype = ObjectType()
+    objectype.identifier = "http://example.com/objectypes/1"
+    subject = Concept()
+    subject.identifier = "https://example.com/subjects/1"
+    objectype.subject = subject
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+    @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+    <http://example.com/objectypes/1> a modelldcatno:ObjectType ;
+        dct:subject <https://example.com/subjects/1> ;
+    .
+     <https://example.com/subjects/1> a skos:Concept .
+
+    """
+    g1 = Graph().parse(data=objectype.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+# ---------------------------------------------------------------------- #
+# Utils for displaying debug information
+
+
+def _dump_diff(g1: Graph, g2: Graph) -> None:
+    in_both, in_first, in_second = graph_diff(g1, g2)
+    print("\nin both:")
+    _dump_turtle(in_both)
+    print("\nin first:")
+    _dump_turtle(in_first)
+    print("\nin second:")
+    _dump_turtle(in_second)
+
+
+def _dump_turtle(g: Graph) -> None:
+    for _l in g.serialize(format="turtle").splitlines():
+        if _l:
+            print(_l.decode())

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -88,7 +88,7 @@ def test_to_graph_should_return_has_object_type_both_identifiers() -> None:
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         <http://example.com/roles/1> a modelldcatno:Role ;
-        modelldcatno:hasObjectType <http://example.com/objecttypes/1> .
+            modelldcatno:hasObjectType <http://example.com/objecttypes/1> .
 
         <http://example.com/objecttypes/1> a modelldcatno:ObjectType ;
 

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -1,0 +1,330 @@
+"""Test cases for the role module."""
+
+from concepttordf import Concept
+import pytest
+from rdflib import Graph
+from rdflib.compare import graph_diff, isomorphic
+
+from modelldcatnotordf.modelldcatno import ObjectType
+from modelldcatnotordf.modelldcatno import Role
+
+"""
+A test class for testing the class Role.
+
+"""
+
+
+def test_instantiate_role() -> None:
+    """It returns a TypeErro exception."""
+    try:
+        _ = Role()
+    except Exception:
+        pytest.fail("Unexpected Exception ..")
+
+
+def test_to_graph_should_return_blank_node() -> None:
+    """It returns a role graph as blank node isomorphic to spec."""
+    role = Role()
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+        [ a modelldcatno:Role ] .
+
+        """
+    g1 = Graph().parse(data=role.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_identifier() -> None:
+    """It returns an identifier graph isomorphic to spec."""
+    role = Role()
+    role.identifier = "http://example.com/roles/1"
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+        <http://example.com/roles/1> a modelldcatno:Role .
+
+        """
+    g1 = Graph().parse(data=role.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_has_object_type_both_identifiers() -> None:
+    """It returns a has_object_type graph isomorphic to spec."""
+    role = Role()
+    role.identifier = "http://example.com/roles/1"
+
+    objecttype = ObjectType()
+    objecttype.identifier = "http://example.com/objecttypes/1"
+    role._has_object_type = objecttype
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+        <http://example.com/roles/1> a modelldcatno:Role ;
+        modelldcatno:hasObjectType <http://example.com/objecttypes/1> .
+
+        <http://example.com/objecttypes/1> a modelldcatno:ObjectType ;
+
+        .
+        """
+    g1 = Graph().parse(data=role.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_has_object_type_blank_node_role_identifier() -> None:
+    """It returns a has_object_type graph isomorphic to spec."""
+    role = Role()
+    role.identifier = "http://example.com/roles/1"
+
+    objecttype = ObjectType()
+    role.has_object_type = objecttype
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+        <http://example.com/roles/1> a modelldcatno:Role ;
+            modelldcatno:hasObjectType [ a modelldcatno:ObjectType ] .
+
+        """
+    g1 = Graph().parse(data=role.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_has_object_type_blank_node_objecttype() -> None:
+    """It returns a has_object_type graph isomorphic to spec."""
+    role = Role()
+
+    objecttype = ObjectType()
+    objecttype.identifier = "http://example.com/objecttypes/1"
+    role.has_object_type = objecttype
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+        [ a modelldcatno:Role ;
+            modelldcatno:hasObjectType <http://example.com/objecttypes/1>
+        ] .
+
+        <http://example.com/objecttypes/1> a modelldcatno:ObjectType .
+
+        """
+    g1 = Graph().parse(data=role.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_has_object_type_blank_nodes() -> None:
+    """It returns a has_object_type graph isomorphic to spec."""
+    role = Role()
+
+    objecttype = ObjectType()
+    role.has_object_type = objecttype
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+        [ a modelldcatno:Role ;
+            modelldcatno:hasObjectType [ a modelldcatno:ObjectType ]
+        ] .
+        """
+    g1 = Graph().parse(data=role.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_min_occurs() -> None:
+    """It returns a min_occurs graph isomorphic to spec."""
+    role = Role()
+    role.identifier = "http://example.com/roles/1"
+    role.min_occurs = 1
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        <http://example.com/roles/1> a modelldcatno:Role ;
+            xsd:minOccurs 1 .
+
+        """
+    g1 = Graph().parse(data=role.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_max_occurs() -> None:
+    """It returns a max_occurs graph isomorphic to spec."""
+    role = Role()
+    role.identifier = "http://example.com/roles/1"
+    role.max_occurs = 1
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        <http://example.com/roles/1> a modelldcatno:Role ;
+            xsd:maxOccurs 1 .
+
+        """
+    g1 = Graph().parse(data=role.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_title() -> None:
+    """It returns a title graph isomorphic to spec."""
+    """It returns an identifier graph isomorphic to spec."""
+
+    role = Role()
+    role.identifier = "http://example.com/roles/1"
+    role.title = {"nb": "Tittel 1", "en": "Title 1"}
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+        <http://example.com/roles/1> a modelldcatno:Role;
+                dct:title   "Title 1"@en, "Tittel 1"@nb ;
+        .
+        """
+    g1 = Graph().parse(data=role.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+def test_to_graph_should_return_subject() -> None:
+    """It returns a subject graph isomorphic to spec."""
+    role = Role()
+    role.identifier = "http://example.com/roles/1"
+    subject = Concept()
+    subject.identifier = "https://example.com/subjects/1"
+    role.subject = subject
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+    @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+    <http://example.com/roles/1> a modelldcatno:Role ;
+        dct:subject <https://example.com/subjects/1> ;
+    .
+     <https://example.com/subjects/1> a skos:Concept .
+
+    """
+    g1 = Graph().parse(data=role.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
+# ---------------------------------------------------------------------- #
+# Utils for displaying debug information
+
+
+def _dump_diff(g1: Graph, g2: Graph) -> None:
+    in_both, in_first, in_second = graph_diff(g1, g2)
+    print("\nin both:")
+    _dump_turtle(in_both)
+    print("\nin first:")
+    _dump_turtle(in_first)
+    print("\nin second:")
+    _dump_turtle(in_second)
+
+
+def _dump_turtle(g: Graph) -> None:
+    for _l in g.serialize(format="turtle").splitlines():
+        if _l:
+            print(_l.decode())


### PR DESCRIPTION
Dagens PR:

- modelldcatno:ObjecType og modelldcatno:Role

- Nytt denne gang er subklassing av modelldcatno:Property (modelldcatno:Role) og modelldcatno:Modelement(modelldcatno:ObjecType). Dette mønsteret vil gå igjen i flere av klassene fremover. 

