### PR TITLE
Title fra egenskap blir lagt til på overordnet element i opprettelse av rdf

### DIFF
--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -217,7 +217,10 @@ class InformationModel(Resource):
                     _modelelement = BNode()
 
                 for _s, p, o in modelelement._to_graph().triples((None, None, None)):
-                    self._g.add((_modelelement, p, o))
+                    if isinstance(_modelelement, BNode):
+                        self._g.add((_modelelement, p, o))
+                    else:
+                        self._g.add((_s, p, o))
 
                 self._g.add(
                     (
@@ -240,7 +243,10 @@ class InformationModel(Resource):
             for _s, p, o in self.licensedocument._to_graph().triples(
                 (None, None, None)
             ):
-                self._g.add((_licensedocument, p, o))
+                if isinstance(_licensedocument, BNode):
+                    self._g.add((_licensedocument, p, o))
+                else:
+                    self._g.add((_s, p, o))
 
             self._g.add((URIRef(self.identifier), DCT.license, _licensedocument))
 
@@ -399,7 +405,10 @@ class ModelElement:
                     _has_property = BNode()
 
                 for _s, p, o in has_property._to_graph().triples((None, None, None)):
-                    self._g.add((_has_property, p, o))
+                    if isinstance(_has_property, BNode):
+                        self._g.add((_has_property, p, o))
+                    else:
+                        self._g.add((_s, p, o))
 
                 self._g.add(
                     (
@@ -579,7 +588,10 @@ class ModelProperty:
                     _has_type = BNode()
 
                 for _s, p, o in has_type._to_graph().triples((None, None, None)):
-                    self._g.add((_has_type, p, o))
+                    if isinstance(_has_type, BNode):
+                        self._g.add((_has_type, p, o))
+                    else:
+                        self._g.add((_s, p, o))
 
                 self._g.add(
                     (
@@ -665,7 +677,10 @@ class Role(ModelProperty):
             for _s, p, o in self._has_object_type._to_graph().triples(
                 (None, None, None)
             ):
-                self._g.add((_has_object_type, p, o))
+                if isinstance(_has_object_type, BNode):
+                    self._g.add((_has_object_type, p, o))
+                else:
+                    self._g.add((_s, p, o))
 
             self._g.add((_self, MODELLDCATNO.hasObjectType, _has_object_type))
 
@@ -974,7 +989,10 @@ class Composition(ModelProperty):
                 _contains = BNode()
 
             for _s, p, o in self._contains._to_graph().triples((None, None, None)):
-                self._g.add((_contains, p, o))
+                if isinstance(_contains, BNode):
+                    self._g.add((_contains, p, o))
+                else:
+                    self._g.add((_s, p, o))
 
             self._g.add((_self, MODELLDCATNO.contains, _contains))
 
@@ -1045,7 +1063,10 @@ class Collection(ModelProperty):
                 _has_member = BNode()
 
             for _s, p, o in self._has_member._to_graph().triples((None, None, None)):
-                self._g.add((_has_member, p, o))
+                if isinstance(_has_member, BNode):
+                    self._g.add((_has_member, p, o))
+                else:
+                    self._g.add((_s, p, o))
 
             self._g.add((_self, MODELLDCATNO.hasMember, _has_member))
 
@@ -1116,7 +1137,10 @@ class Association(ModelProperty):
                 _refers_to = BNode()
 
             for _s, p, o in self._refers_to._to_graph().triples((None, None, None)):
-                self._g.add((_refers_to, p, o))
+                if isinstance(_refers_to, BNode):
+                    self._g.add((_refers_to, p, o))
+                else:
+                    self._g.add((_s, p, o))
 
             self._g.add((_self, MODELLDCATNO.refersTo, _refers_to))
 
@@ -1196,7 +1220,10 @@ class Choice(ModelProperty):
                     _has_some = BNode()
 
                 for _s, p, o in has_some._to_graph().triples((None, None, None)):
-                    self._g.add((_has_some, p, o))
+                    if isinstance(_has_some, BNode):
+                        self._g.add((_has_some, p, o))
+                    else:
+                        self._g.add((_s, p, o))
 
                 self._g.add((_self, MODELLDCATNO.hasSome, _has_some))
 
@@ -1315,7 +1342,10 @@ class Attribute(ModelProperty):
             for _s, p, o in self._contains_object_type._to_graph().triples(
                 (None, None, None)
             ):
-                self._g.add((_contains_object_type, p, o))
+                if isinstance(_contains_object_type, BNode):
+                    self._g.add((_contains_object_type, p, o))
+                else:
+                    self._g.add((_s, p, o))
 
             self._g.add((_self, MODELLDCATNO.containsObjectType, _contains_object_type))
 
@@ -1331,7 +1361,10 @@ class Attribute(ModelProperty):
             for _s, p, o in self._has_simple_type._to_graph().triples(
                 (None, None, None)
             ):
-                self._g.add((_has_simple_type, p, o))
+                if isinstance(_has_simple_type, BNode):
+                    self._g.add((_has_simple_type, p, o))
+                else:
+                    self._g.add((_s, p, o))
 
             self._g.add((_self, MODELLDCATNO.hasSimpleType, _has_simple_type))
 
@@ -1345,7 +1378,10 @@ class Attribute(ModelProperty):
                 _has_data_type = BNode()
 
             for _s, p, o in self._has_data_type._to_graph().triples((None, None, None)):
-                self._g.add((_has_data_type, p, o))
+                if isinstance(_has_data_type, BNode):
+                    self._g.add((_has_data_type, p, o))
+                else:
+                    self._g.add((_s, p, o))
 
             self._g.add((_self, MODELLDCATNO.hasDataType, _has_data_type))
 
@@ -1362,7 +1398,10 @@ class Attribute(ModelProperty):
             for _s, p, o in self._has_value_from._to_graph().triples(
                 (None, None, None)
             ):
-                self._g.add((_has_value_from, p, o))
+                if isinstance(_has_value_from, BNode):
+                    self._g.add((_has_value_from, p, o))
+                else:
+                    self._g.add((_s, p, o))
 
             self._g.add((_self, MODELLDCATNO.hasValueFrom, _has_value_from))
 
@@ -1439,7 +1478,10 @@ class Specialization(ModelProperty):
             for _s, p, o in self._has_general_concept._to_graph().triples(
                 (None, None, None)
             ):
-                self._g.add((has_general_concept, p, o))
+                if isinstance(has_general_concept, BNode):
+                    self._g.add((has_general_concept, p, o))
+                else:
+                    self._g.add((_s, p, o))
 
             self._g.add((_self, MODELLDCATNO.hasGeneralConcept, has_general_concept))
 
@@ -1510,7 +1552,10 @@ class Realization(ModelProperty):
                 _has_supplier = BNode()
 
             for _s, p, o in self._has_supplier._to_graph().triples((None, None, None)):
-                self._g.add((_has_supplier, p, o))
+                if isinstance(_has_supplier, BNode):
+                    self._g.add((_has_supplier, p, o))
+                else:
+                    self._g.add((_s, p, o))
 
             self._g.add((_self, MODELLDCATNO.hasSupplier, _has_supplier))
 
@@ -1583,7 +1628,10 @@ class Abstraction(ModelProperty):
             for _s, p, o in self._is_abstraction_of._to_graph().triples(
                 (None, None, None)
             ):
-                self._g.add((_is_abstraction_of, p, o))
+                if isinstance(_is_abstraction_of, BNode):
+                    self._g.add((_is_abstraction_of, p, o))
+                else:
+                    self._g.add((_s, p, o))
 
             self._g.add((_self, MODELLDCATNO.isAbstractionOf, _is_abstraction_of))
 
@@ -1912,7 +1960,12 @@ class CodeElement:
                     _in_scheme = BNode()
 
                 for _s, p, o in in_scheme._to_graph().triples((None, None, None)):
-                    self._g.add((_in_scheme, p, o))
+
+                    if isinstance(_in_scheme, BNode):
+                        self._g.add((_in_scheme, p, o))
+
+                    else:
+                        self._g.add((_s, p, o))
 
                 self._g.add((_self, SKOS.inScheme, _in_scheme))
 
@@ -1928,6 +1981,9 @@ class CodeElement:
                     _top_concept_of = BNode()
 
                 for _s, p, o in top_concept_of._to_graph().triples((None, None, None)):
-                    self._g.add((_top_concept_of, p, o))
+                    if isinstance(_top_concept_of, BNode):
+                        self._g.add((_top_concept_of, p, o))
+                    else:
+                        self._g.add((_s, p, o))
 
                 self._g.add((_self, SKOS.topConceptOf, _top_concept_of))

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -217,10 +217,11 @@ class InformationModel(Resource):
                     _modelelement = BNode()
 
                 for _s, p, o in modelelement._to_graph().triples((None, None, None)):
-                    if isinstance(_modelelement, BNode):
-                        self._g.add((_modelelement, p, o))
-                    else:
-                        self._g.add((_s, p, o))
+                    self._g.add(
+                        (_modelelement, p, o)
+                        if isinstance(_modelelement, BNode)
+                        else (_s, p, o)
+                    )
 
                 self._g.add(
                     (
@@ -243,10 +244,11 @@ class InformationModel(Resource):
             for _s, p, o in self.licensedocument._to_graph().triples(
                 (None, None, None)
             ):
-                if isinstance(_licensedocument, BNode):
-                    self._g.add((_licensedocument, p, o))
-                else:
-                    self._g.add((_s, p, o))
+                self._g.add(
+                    (_licensedocument, p, o)
+                    if isinstance(_licensedocument, BNode)
+                    else (_s, p, o)
+                )
 
             self._g.add((URIRef(self.identifier), DCT.license, _licensedocument))
 
@@ -405,10 +407,11 @@ class ModelElement:
                     _has_property = BNode()
 
                 for _s, p, o in has_property._to_graph().triples((None, None, None)):
-                    if isinstance(_has_property, BNode):
-                        self._g.add((_has_property, p, o))
-                    else:
-                        self._g.add((_s, p, o))
+                    self._g.add(
+                        (_has_property, p, o)
+                        if isinstance(_has_property, BNode)
+                        else (_s, p, o)
+                    )
 
                 self._g.add(
                     (
@@ -588,10 +591,11 @@ class ModelProperty:
                     _has_type = BNode()
 
                 for _s, p, o in has_type._to_graph().triples((None, None, None)):
-                    if isinstance(_has_type, BNode):
-                        self._g.add((_has_type, p, o))
-                    else:
-                        self._g.add((_s, p, o))
+                    self._g.add(
+                        (_has_type, p, o)
+                        if isinstance(_has_type, BNode)
+                        else (_s, p, o)
+                    )
 
                 self._g.add(
                     (
@@ -677,10 +681,11 @@ class Role(ModelProperty):
             for _s, p, o in self._has_object_type._to_graph().triples(
                 (None, None, None)
             ):
-                if isinstance(_has_object_type, BNode):
-                    self._g.add((_has_object_type, p, o))
-                else:
-                    self._g.add((_s, p, o))
+                self._g.add(
+                    (_has_object_type, p, o)
+                    if isinstance(_has_object_type, BNode)
+                    else (_s, p, o)
+                )
 
             self._g.add((_self, MODELLDCATNO.hasObjectType, _has_object_type))
 
@@ -989,10 +994,9 @@ class Composition(ModelProperty):
                 _contains = BNode()
 
             for _s, p, o in self._contains._to_graph().triples((None, None, None)):
-                if isinstance(_contains, BNode):
-                    self._g.add((_contains, p, o))
-                else:
-                    self._g.add((_s, p, o))
+                self._g.add(
+                    (_contains, p, o) if isinstance(_contains, BNode) else (_s, p, o)
+                )
 
             self._g.add((_self, MODELLDCATNO.contains, _contains))
 
@@ -1063,10 +1067,11 @@ class Collection(ModelProperty):
                 _has_member = BNode()
 
             for _s, p, o in self._has_member._to_graph().triples((None, None, None)):
-                if isinstance(_has_member, BNode):
-                    self._g.add((_has_member, p, o))
-                else:
-                    self._g.add((_s, p, o))
+                self._g.add(
+                    (_has_member, p, o)
+                    if isinstance(_has_member, BNode)
+                    else (_s, p, o)
+                )
 
             self._g.add((_self, MODELLDCATNO.hasMember, _has_member))
 
@@ -1137,10 +1142,9 @@ class Association(ModelProperty):
                 _refers_to = BNode()
 
             for _s, p, o in self._refers_to._to_graph().triples((None, None, None)):
-                if isinstance(_refers_to, BNode):
-                    self._g.add((_refers_to, p, o))
-                else:
-                    self._g.add((_s, p, o))
+                self._g.add(
+                    (_refers_to, p, o) if isinstance(_refers_to, BNode) else (_s, p, o)
+                )
 
             self._g.add((_self, MODELLDCATNO.refersTo, _refers_to))
 
@@ -1220,10 +1224,11 @@ class Choice(ModelProperty):
                     _has_some = BNode()
 
                 for _s, p, o in has_some._to_graph().triples((None, None, None)):
-                    if isinstance(_has_some, BNode):
-                        self._g.add((_has_some, p, o))
-                    else:
-                        self._g.add((_s, p, o))
+                    self._g.add(
+                        (_has_some, p, o)
+                        if isinstance(_has_some, BNode)
+                        else (_s, p, o)
+                    )
 
                 self._g.add((_self, MODELLDCATNO.hasSome, _has_some))
 
@@ -1342,10 +1347,11 @@ class Attribute(ModelProperty):
             for _s, p, o in self._contains_object_type._to_graph().triples(
                 (None, None, None)
             ):
-                if isinstance(_contains_object_type, BNode):
-                    self._g.add((_contains_object_type, p, o))
-                else:
-                    self._g.add((_s, p, o))
+                self._g.add(
+                    (_contains_object_type, p, o)
+                    if isinstance(_contains_object_type, BNode)
+                    else (_s, p, o)
+                )
 
             self._g.add((_self, MODELLDCATNO.containsObjectType, _contains_object_type))
 
@@ -1361,10 +1367,11 @@ class Attribute(ModelProperty):
             for _s, p, o in self._has_simple_type._to_graph().triples(
                 (None, None, None)
             ):
-                if isinstance(_has_simple_type, BNode):
-                    self._g.add((_has_simple_type, p, o))
-                else:
-                    self._g.add((_s, p, o))
+                self._g.add(
+                    (_has_simple_type, p, o)
+                    if isinstance(_has_simple_type, BNode)
+                    else (_s, p, o)
+                )
 
             self._g.add((_self, MODELLDCATNO.hasSimpleType, _has_simple_type))
 
@@ -1378,10 +1385,11 @@ class Attribute(ModelProperty):
                 _has_data_type = BNode()
 
             for _s, p, o in self._has_data_type._to_graph().triples((None, None, None)):
-                if isinstance(_has_data_type, BNode):
-                    self._g.add((_has_data_type, p, o))
-                else:
-                    self._g.add((_s, p, o))
+                self._g.add(
+                    (_has_data_type, p, o)
+                    if isinstance(_has_data_type, BNode)
+                    else (_s, p, o)
+                )
 
             self._g.add((_self, MODELLDCATNO.hasDataType, _has_data_type))
 
@@ -1398,10 +1406,11 @@ class Attribute(ModelProperty):
             for _s, p, o in self._has_value_from._to_graph().triples(
                 (None, None, None)
             ):
-                if isinstance(_has_value_from, BNode):
-                    self._g.add((_has_value_from, p, o))
-                else:
-                    self._g.add((_s, p, o))
+                self._g.add(
+                    (_has_value_from, p, o)
+                    if isinstance(_has_value_from, BNode)
+                    else (_s, p, o)
+                )
 
             self._g.add((_self, MODELLDCATNO.hasValueFrom, _has_value_from))
 
@@ -1471,19 +1480,20 @@ class Specialization(ModelProperty):
         if getattr(self, "has_general_concept", None):
 
             if getattr(self._has_general_concept, "identifier", None):
-                has_general_concept = URIRef(self.has_general_concept.identifier)
+                _has_general_concept = URIRef(self.has_general_concept.identifier)
             else:
-                has_general_concept = BNode()
+                _has_general_concept = BNode()
 
             for _s, p, o in self._has_general_concept._to_graph().triples(
                 (None, None, None)
             ):
-                if isinstance(has_general_concept, BNode):
-                    self._g.add((has_general_concept, p, o))
-                else:
-                    self._g.add((_s, p, o))
+                self._g.add(
+                    (_has_general_concept, p, o)
+                    if isinstance(_has_general_concept, BNode)
+                    else (_s, p, o)
+                )
 
-            self._g.add((_self, MODELLDCATNO.hasGeneralConcept, has_general_concept))
+            self._g.add((_self, MODELLDCATNO.hasGeneralConcept, _has_general_concept))
 
 
 class Realization(ModelProperty):
@@ -1552,10 +1562,11 @@ class Realization(ModelProperty):
                 _has_supplier = BNode()
 
             for _s, p, o in self._has_supplier._to_graph().triples((None, None, None)):
-                if isinstance(_has_supplier, BNode):
-                    self._g.add((_has_supplier, p, o))
-                else:
-                    self._g.add((_s, p, o))
+                self._g.add(
+                    (_has_supplier, p, o)
+                    if isinstance(_has_supplier, BNode)
+                    else (_s, p, o)
+                )
 
             self._g.add((_self, MODELLDCATNO.hasSupplier, _has_supplier))
 
@@ -1628,10 +1639,11 @@ class Abstraction(ModelProperty):
             for _s, p, o in self._is_abstraction_of._to_graph().triples(
                 (None, None, None)
             ):
-                if isinstance(_is_abstraction_of, BNode):
-                    self._g.add((_is_abstraction_of, p, o))
-                else:
-                    self._g.add((_s, p, o))
+                self._g.add(
+                    (_is_abstraction_of, p, o)
+                    if isinstance(_is_abstraction_of, BNode)
+                    else (_s, p, o)
+                )
 
             self._g.add((_self, MODELLDCATNO.isAbstractionOf, _is_abstraction_of))
 
@@ -1960,12 +1972,11 @@ class CodeElement:
                     _in_scheme = BNode()
 
                 for _s, p, o in in_scheme._to_graph().triples((None, None, None)):
-
-                    if isinstance(_in_scheme, BNode):
-                        self._g.add((_in_scheme, p, o))
-
-                    else:
-                        self._g.add((_s, p, o))
+                    self._g.add(
+                        (_in_scheme, p, o)
+                        if isinstance(_in_scheme, BNode)
+                        else (_s, p, o)
+                    )
 
                 self._g.add((_self, SKOS.inScheme, _in_scheme))
 
@@ -1981,9 +1992,10 @@ class CodeElement:
                     _top_concept_of = BNode()
 
                 for _s, p, o in top_concept_of._to_graph().triples((None, None, None)):
-                    if isinstance(_top_concept_of, BNode):
-                        self._g.add((_top_concept_of, p, o))
-                    else:
-                        self._g.add((_s, p, o))
+                    self._g.add(
+                        (_top_concept_of, p, o)
+                        if isinstance(_top_concept_of, BNode)
+                        else (_s, p, o)
+                    )
 
                 self._g.add((_self, SKOS.topConceptOf, _top_concept_of))

--- a/tests/testintegration.py
+++ b/tests/testintegration.py
@@ -1,0 +1,69 @@
+"""Test cases for larger scale integration across classes."""
+
+from rdflib import Graph
+
+from modelldcatnotordf.modelldcatno import InformationModel, ModelElement
+from modelldcatnotordf.modelldcatno import ModelProperty
+from tests.testutils import assert_isomorphic
+
+"""
+Test cases for larger scale integration across classes.
+
+"""
+
+
+def test_title_should_be_set_on_correct_element() -> None:
+    """It returns a information model graph isomorphic to spec."""
+    element = ModelElement()
+    element.identifier = "http://example.com/element"
+    element.title = {"nb": "element"}
+
+    prop0 = ModelProperty()
+    prop0.identifier = "http://example.com/egenskap0"
+    prop0.title = {"nb": "egenskap0"}
+    element.has_property.append(prop0)
+
+    prop1 = ModelProperty()
+    prop1.identifier = "http://example.com/egenskap1"
+    prop1.title = {"nb": "egenskap1"}
+    element.has_property.append(prop1)
+
+    prop2 = ModelProperty()
+    prop2.identifier = "http://example.com/egenskap2"
+    prop2.title = {"nb": "egenskap2"}
+    element.has_property.append(prop2)
+
+    model = InformationModel()
+    model.identifier = "http://example.com/modell"
+    model.modelelements.append(element)
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+        <http://example.com/modell> a modelldcatno:InformationModel ;
+                modelldcatno:containsModelelement <http://example.com/element> .
+
+        <http://example.com/egenskap0> a modelldcatno:Property ;
+                dct:title "egenskap0"@nb .
+
+        <http://example.com/egenskap1> a modelldcatno:Property ;
+                dct:title "egenskap1"@nb .
+
+        <http://example.com/egenskap2> a modelldcatno:Property ;
+                dct:title "egenskap2"@nb .
+
+        <http://example.com/element> a modelldcatno:ModelElement ;
+                dct:title "element"@nb ;
+                modelldcatno:hasProperty <http://example.com/egenskap0>,
+                                        <http://example.com/egenskap1>,
+                                        <http://example.com/egenskap2> .
+          """
+
+    g1 = Graph().parse(data=model.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)


### PR DESCRIPTION
Feilen oppstår når ved serialisering av object properties som er klasser som kan være blanke noder:

```
    for _s, p, o in modelelement._to_graph().triples((None, None, None)):
                        self._g.add((_modelelement, p, o))
```

`_modelelement` er enten URI eller bnode alt ettersom vi har identifier. Grunnen til at vi legger til `_modelelement` som subjekt i trippelet er at hvis det er snakk om blanke noder så vil ikke parseren forstå at det snakk om samme node ved sammenligning:

```
in first:
@prefix ns1: <https://data.norge.no/vocabulary/modelldcatno#> .
<http://example.com/informationmodels/1> ns1:containsModelelement [ ] .
in second:
@prefix ns1: <https://data.norge.no/vocabulary/modelldcatno#> .
<http://example.com/informationmodels/1> ns1:containsModelelement [ ] .
```

Disse to er helt like.

Men bieffekten av dette er at parseren kan legge til andre properties her som skulle være med på noe lenger nede i grafen, slik som det vises av feilen som Nils Ove oppdaget. Foreslår derfor følgende løsning som jeg antar er riktig, med dette så virker den gamle funksjonaliteten pluss den testen som Nils Ove satt opp:

```
for _s, p, o in modelelement._to_graph().triples((None, None, None)):
  if isinstance(_modelelement, BNode):
      self._g.add((_modelelement, p, o))
  else:
      self._g.add((_s, p, o))
```

Feilen har vært  konsekvent gjennomgående i hele modelldcatno og utgjør muligvis også et problem i dcat