### PR TITLE
fix : #49 class ModelElement abstract

### DIFF
--- a/tests/test_abstraction.py
+++ b/tests/test_abstraction.py
@@ -3,7 +3,7 @@
 import pytest
 from rdflib import Graph
 
-from modelldcatnotordf.modelldcatno import Abstraction, ModelElement
+from modelldcatnotordf.modelldcatno import Abstraction, ObjectType
 from tests.testutils import assert_isomorphic
 
 """
@@ -66,7 +66,7 @@ def test_to_graph_should_return_is_abstraction_of_both_identifiers() -> None:
     abstraction = Abstraction()
     abstraction.identifier = "http://example.com/abstractions/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     abstraction.is_abstraction_of = modelelement
 
@@ -80,7 +80,7 @@ def test_to_graph_should_return_is_abstraction_of_both_identifiers() -> None:
         <http://example.com/abstractions/1> a modelldcatno:Abstraction ;
             modelldcatno:isAbstractionOf <http://example.com/modelelements/1> .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType ;
 
         .
         """
@@ -95,7 +95,7 @@ def test_to_graph_should_return_is_abstr_blank_node_abstr_identifier() -> None:
     abstraction = Abstraction()
     abstraction.identifier = "http://example.com/abstractions/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     abstraction.is_abstraction_of = modelelement
 
     src = """
@@ -106,7 +106,7 @@ def test_to_graph_should_return_is_abstr_blank_node_abstr_identifier() -> None:
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         <http://example.com/abstractions/1> a modelldcatno:Abstraction ;
-            modelldcatno:isAbstractionOf [ a modelldcatno:ModelElement ] .
+            modelldcatno:isAbstractionOf [ a modelldcatno:ObjectType ] .
 
         """
     g1 = Graph().parse(data=abstraction.to_rdf(), format="turtle")
@@ -119,7 +119,7 @@ def test_to_graph_should_return_is_abstr_of_bnode_modelelement_id() -> None:
     """It returns a is_abstraction_of graph isomorphic to spec."""
     abstraction = Abstraction()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     abstraction.is_abstraction_of = modelelement
 
@@ -134,7 +134,7 @@ def test_to_graph_should_return_is_abstr_of_bnode_modelelement_id() -> None:
             modelldcatno:isAbstractionOf <http://example.com/modelelements/1>
         ] .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement .
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType .
 
         """
     g1 = Graph().parse(data=abstraction.to_rdf(), format="turtle")
@@ -147,7 +147,7 @@ def test_to_graph_should_return_is_abstraction_of_blank_nodes() -> None:
     """It returns a is_abstraction_of graph isomorphic to spec."""
     abstraction = Abstraction()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     abstraction.is_abstraction_of = modelelement
 
     src = """
@@ -158,7 +158,7 @@ def test_to_graph_should_return_is_abstraction_of_blank_nodes() -> None:
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         [ a modelldcatno:Abstraction ;
-            modelldcatno:isAbstractionOf [ a modelldcatno:ModelElement ]
+            modelldcatno:isAbstractionOf [ a modelldcatno:ObjectType ]
         ] .
         """
     g1 = Graph().parse(data=abstraction.to_rdf(), format="turtle")

--- a/tests/test_association.py
+++ b/tests/test_association.py
@@ -3,7 +3,7 @@
 import pytest
 from rdflib import Graph
 
-from modelldcatnotordf.modelldcatno import Association, ModelElement
+from modelldcatnotordf.modelldcatno import Association, ObjectType
 from tests.testutils import assert_isomorphic
 
 """
@@ -66,7 +66,7 @@ def test_to_graph_should_return_refers_to_both_identifiers() -> None:
     association = Association()
     association.identifier = "http://example.com/associations/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     association.refers_to = modelelement
 
@@ -80,7 +80,7 @@ def test_to_graph_should_return_refers_to_both_identifiers() -> None:
         <http://example.com/associations/1> a modelldcatno:Association ;
             modelldcatno:refersTo <http://example.com/modelelements/1> .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType ;
 
         .
         """
@@ -95,7 +95,7 @@ def test_to_graph_should_return_refers_to_blank_node_association_identifier() ->
     association = Association()
     association.identifier = "http://example.com/associations/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     association.refers_to = modelelement
 
     src = """
@@ -106,7 +106,7 @@ def test_to_graph_should_return_refers_to_blank_node_association_identifier() ->
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         <http://example.com/associations/1> a modelldcatno:Association ;
-            modelldcatno:refersTo [ a modelldcatno:ModelElement ] .
+            modelldcatno:refersTo [ a modelldcatno:ObjectType ] .
 
         """
     g1 = Graph().parse(data=association.to_rdf(), format="turtle")
@@ -119,7 +119,7 @@ def test_to_graph_should_return_refers_to_blank_node_modelelement_identifier() -
     """It returns a refers_to graph isomorphic to spec."""
     association = Association()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     association.refers_to = modelelement
 
@@ -134,7 +134,7 @@ def test_to_graph_should_return_refers_to_blank_node_modelelement_identifier() -
             modelldcatno:refersTo <http://example.com/modelelements/1>
         ] .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement .
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType .
 
         """
     g1 = Graph().parse(data=association.to_rdf(), format="turtle")
@@ -147,7 +147,7 @@ def test_to_graph_should_return_refers_to_blank_nodes() -> None:
     """It returns a refers_to graph isomorphic to spec."""
     association = Association()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     association.refers_to = modelelement
 
     src = """
@@ -158,7 +158,7 @@ def test_to_graph_should_return_refers_to_blank_nodes() -> None:
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         [ a modelldcatno:Association ;
-            modelldcatno:refersTo [ a modelldcatno:ModelElement ]
+            modelldcatno:refersTo [ a modelldcatno:ObjectType ]
         ] .
         """
     g1 = Graph().parse(data=association.to_rdf(), format="turtle")

--- a/tests/test_choice.py
+++ b/tests/test_choice.py
@@ -4,7 +4,7 @@ from typing import List
 import pytest
 from rdflib import Graph
 
-from modelldcatnotordf.modelldcatno import Choice, ModelElement
+from modelldcatnotordf.modelldcatno import Choice, ModelElement, ObjectType
 from tests.testutils import assert_isomorphic
 
 """
@@ -67,15 +67,13 @@ def test_to_graph_should_return_has_some_both_identifiers() -> None:
     choice = Choice()
     choice.identifier = "http://example.com/choices/1"
 
-    modelelement1 = ModelElement()
+    modelelement1 = ObjectType()
     modelelement1.identifier = "http://example.com/modelelements/1"
 
-    modelelement2 = ModelElement()
+    modelelement2 = ObjectType()
     modelelement2.identifier = "http://example.com/modelelements/2"
 
-    has_somes: List[ModelElement] = []
-    has_somes.append(modelelement1)
-    has_somes.append(modelelement2)
+    has_somes: List[ModelElement] = [modelelement1, modelelement2]
     choice.has_some = has_somes
 
     src = """
@@ -91,8 +89,8 @@ def test_to_graph_should_return_has_some_both_identifiers() -> None:
             modelldcatno:hasSome <http://example.com/modelelements/2> ;
 
         .
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement .
-        <http://example.com/modelelements/2> a modelldcatno:ModelElement .
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType .
+        <http://example.com/modelelements/2> a modelldcatno:ObjectType .
 
         """
     g1 = Graph().parse(data=choice.to_rdf(), format="turtle")
@@ -106,7 +104,7 @@ def test_to_graph_should_return_has_some_blank_node_choice_identifier() -> None:
     choice = Choice()
     choice.identifier = "http://example.com/choices/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     choice.has_some.append(modelelement)
 
     src = """
@@ -117,7 +115,7 @@ def test_to_graph_should_return_has_some_blank_node_choice_identifier() -> None:
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         <http://example.com/choices/1> a modelldcatno:Choice ;
-            modelldcatno:hasSome [ a modelldcatno:ModelElement ] .
+            modelldcatno:hasSome [ a modelldcatno:ObjectType ] .
 
         """
     g1 = Graph().parse(data=choice.to_rdf(), format="turtle")
@@ -130,7 +128,7 @@ def test_to_graph_should_return_has_some_blank_node_modelelement_identifier() ->
     """It returns a has_some graph isomorphic to spec."""
     choice = Choice()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     choice.has_some.append(modelelement)
 
@@ -145,7 +143,7 @@ def test_to_graph_should_return_has_some_blank_node_modelelement_identifier() ->
             modelldcatno:hasSome <http://example.com/modelelements/1>
         ] .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement .
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType .
 
         """
     g1 = Graph().parse(data=choice.to_rdf(), format="turtle")
@@ -158,7 +156,7 @@ def test_to_graph_should_return_has_some_blank_nodes() -> None:
     """It returns a has_some graph isomorphic to spec."""
     choice = Choice()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     choice.has_some.append(modelelement)
 
     src = """
@@ -169,7 +167,7 @@ def test_to_graph_should_return_has_some_blank_nodes() -> None:
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         [ a modelldcatno:Choice ;
-            modelldcatno:hasSome [ a modelldcatno:ModelElement ]
+            modelldcatno:hasSome [ a modelldcatno:ObjectType ]
         ] .
         """
     g1 = Graph().parse(data=choice.to_rdf(), format="turtle")

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -3,7 +3,7 @@
 import pytest
 from rdflib import Graph
 
-from modelldcatnotordf.modelldcatno import Collection, ModelElement
+from modelldcatnotordf.modelldcatno import Collection, ObjectType
 from tests.testutils import assert_isomorphic
 
 """
@@ -66,7 +66,7 @@ def test_to_graph_should_return_has_member_both_identifiers() -> None:
     collection = Collection()
     collection.identifier = "http://example.com/collections/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     collection.has_member = modelelement
 
@@ -80,7 +80,7 @@ def test_to_graph_should_return_has_member_both_identifiers() -> None:
         <http://example.com/collections/1> a modelldcatno:Collection ;
             modelldcatno:hasMember <http://example.com/modelelements/1> .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType ;
 
         .
         """
@@ -95,7 +95,7 @@ def test_to_graph_should_return_has_member_blank_node_collection_identifier() ->
     collection = Collection()
     collection.identifier = "http://example.com/collections/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     collection.has_member = modelelement
 
     src = """
@@ -106,7 +106,7 @@ def test_to_graph_should_return_has_member_blank_node_collection_identifier() ->
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         <http://example.com/collections/1> a modelldcatno:Collection ;
-            modelldcatno:hasMember [ a modelldcatno:ModelElement ] .
+            modelldcatno:hasMember [ a modelldcatno:ObjectType ] .
 
         """
     g1 = Graph().parse(data=collection.to_rdf(), format="turtle")
@@ -119,7 +119,7 @@ def test_to_graph_should_return_has_member_blank_node_modelelement_identifier() 
     """It returns a has_member graph isomorphic to spec."""
     collection = Collection()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     collection.has_member = modelelement
 
@@ -134,7 +134,7 @@ def test_to_graph_should_return_has_member_blank_node_modelelement_identifier() 
             modelldcatno:hasMember <http://example.com/modelelements/1>
         ] .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement .
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType .
 
         """
     g1 = Graph().parse(data=collection.to_rdf(), format="turtle")
@@ -147,7 +147,7 @@ def test_to_graph_should_return_has_member_blank_nodes() -> None:
     """It returns a has_member graph isomorphic to spec."""
     collection = Collection()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     collection.has_member = modelelement
 
     src = """
@@ -158,7 +158,7 @@ def test_to_graph_should_return_has_member_blank_nodes() -> None:
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         [ a modelldcatno:Collection ;
-            modelldcatno:hasMember [ a modelldcatno:ModelElement ]
+            modelldcatno:hasMember [ a modelldcatno:ObjectType ]
         ] .
         """
     g1 = Graph().parse(data=collection.to_rdf(), format="turtle")

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -3,7 +3,7 @@
 import pytest
 from rdflib import Graph
 
-from modelldcatnotordf.modelldcatno import Composition, ModelElement
+from modelldcatnotordf.modelldcatno import Composition, ObjectType
 from tests.testutils import assert_isomorphic
 
 """
@@ -66,7 +66,7 @@ def test_to_graph_should_return_contains_both_identifiers() -> None:
     composition = Composition()
     composition.identifier = "http://example.com/compositions/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     composition.contains = modelelement
 
@@ -80,7 +80,7 @@ def test_to_graph_should_return_contains_both_identifiers() -> None:
         <http://example.com/compositions/1> a modelldcatno:Composition ;
             modelldcatno:contains <http://example.com/modelelements/1> .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType ;
 
         .
         """
@@ -95,7 +95,7 @@ def test_to_graph_should_return_contains_blank_node_composition_identifier() -> 
     composition = Composition()
     composition.identifier = "http://example.com/compositions/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     composition.contains = modelelement
 
     src = """
@@ -106,7 +106,7 @@ def test_to_graph_should_return_contains_blank_node_composition_identifier() -> 
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         <http://example.com/compositions/1> a modelldcatno:Composition ;
-            modelldcatno:contains [ a modelldcatno:ModelElement ] .
+            modelldcatno:contains [ a modelldcatno:ObjectType ] .
 
         """
     g1 = Graph().parse(data=composition.to_rdf(), format="turtle")
@@ -119,7 +119,7 @@ def test_to_graph_should_return_contains_blank_node_modelelement_identifier() ->
     """It returns a contains graph isomorphic to spec."""
     composition = Composition()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     composition.contains = modelelement
 
@@ -134,7 +134,7 @@ def test_to_graph_should_return_contains_blank_node_modelelement_identifier() ->
             modelldcatno:contains <http://example.com/modelelements/1>
         ] .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement .
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType .
 
         """
     g1 = Graph().parse(data=composition.to_rdf(), format="turtle")
@@ -147,7 +147,7 @@ def test_to_graph_should_return_contains_blank_nodes() -> None:
     """It returns a contains graph isomorphic to spec."""
     composition = Composition()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     composition.contains = modelelement
 
     src = """
@@ -158,7 +158,7 @@ def test_to_graph_should_return_contains_blank_nodes() -> None:
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         [ a modelldcatno:Composition ;
-            modelldcatno:contains [ a modelldcatno:ModelElement ]
+            modelldcatno:contains [ a modelldcatno:ObjectType ]
         ] .
         """
     g1 = Graph().parse(data=composition.to_rdf(), format="turtle")

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -7,8 +7,7 @@ import pytest
 from rdflib import Graph, Namespace
 
 from modelldcatnotordf.licensedocument import LicenseDocument
-from modelldcatnotordf.modelldcatno import InformationModel
-from modelldcatnotordf.modelldcatno import ModelElement
+from modelldcatnotordf.modelldcatno import InformationModel, ModelElement, ObjectType
 from tests.testutils import assert_isomorphic
 
 """
@@ -192,12 +191,11 @@ def test_to_graph_should_return_contains_model_element() -> None:
     """It returns a subject graph isomorphic to spec."""
     informationmodel = InformationModel()
     informationmodel.identifier = "http://example.com/informationmodels/1"
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     modelelement.title = {"nb": "Tittel 1", "en": "Title 1"}
 
-    modelelements: List[ModelElement] = []
-    modelelements.append(modelelement)
+    modelelements: List[ModelElement] = [modelelement]
     informationmodel.modelelements = modelelements
 
     src = """
@@ -211,7 +209,7 @@ def test_to_graph_should_return_contains_model_element() -> None:
     <http://example.com/informationmodels/1> a modelldcatno:InformationModel ;
         modelldcatno:containsModelelement <http://example.com/modelelements/1> .
 
-    <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
+    <http://example.com/modelelements/1> a modelldcatno:ObjectType ;
         dct:title   "Title 1"@en, "Tittel 1"@nb
     .
     """
@@ -226,7 +224,7 @@ def test_to_graph_should_return_modelelements_blank_node() -> None:
     informationmodel = InformationModel()
     informationmodel.identifier = "http://example.com/informationmodels/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     informationmodel.modelelements.append(modelelement)
 
     src = """
@@ -237,7 +235,7 @@ def test_to_graph_should_return_modelelements_blank_node() -> None:
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         <http://example.com/informationmodels/1> a modelldcatno:InformationModel ;
-            modelldcatno:containsModelelement [ a modelldcatno:ModelElement ] .
+            modelldcatno:containsModelelement [ a modelldcatno:ObjectType ] .
 
         """
     g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
@@ -251,7 +249,7 @@ def test_to_graph_should_return_modelelements_blank_node_with_properties() -> No
     informationmodel = InformationModel()
     informationmodel.identifier = "http://example.com/informationmodels/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.title = {"nb": "Tittel 1", "en": "Title 1"}
 
     informationmodel.modelelements.append(modelelement)
@@ -264,7 +262,7 @@ def test_to_graph_should_return_modelelements_blank_node_with_properties() -> No
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         <http://example.com/informationmodels/1> a modelldcatno:InformationModel ;
-            modelldcatno:containsModelelement [ a modelldcatno:ModelElement ;
+            modelldcatno:containsModelelement [ a modelldcatno:ObjectType ;
             dct:title   "Title 1"@en, "Tittel 1"@nb ] .
 
         """

--- a/tests/test_modelelement.py
+++ b/tests/test_modelelement.py
@@ -2,11 +2,9 @@
 from typing import List
 
 from concepttordf import Concept
-import pytest
 from rdflib import Graph
 
-from modelldcatnotordf.modelldcatno import ModelElement
-from modelldcatnotordf.modelldcatno import ModelProperty
+from modelldcatnotordf.modelldcatno import ModelProperty, ObjectType
 from tests.testutils import assert_isomorphic
 
 """
@@ -15,19 +13,11 @@ A test class for testing the class ModelElement.
 """
 
 
-def test_instantiate_modelelement() -> None:
-    """It returns a TypeErro exception."""
-    try:
-        _ = ModelElement()
-    except Exception:
-        pytest.fail("Unexpected Exception ..")
-
-
 def test_to_graph_should_return_title_and_identifier() -> None:
     """It returns a title graph isomorphic to spec."""
     """It returns an identifier graph isomorphic to spec."""
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     modelelement.title = {"nb": "Tittel 1", "en": "Title 1"}
 
@@ -38,7 +28,7 @@ def test_to_graph_should_return_title_and_identifier() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement;
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType;
                 dct:title   "Title 1"@en, "Tittel 1"@nb ;
         .
         """
@@ -50,7 +40,7 @@ def test_to_graph_should_return_title_and_identifier() -> None:
 
 def test_to_graph_should_return_title_and_no_identifier() -> None:
     """It returns a title graph isomorphic to spec."""
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.title = {"nb": "Tittel 1", "en": "Title 1"}
 
     src = """
@@ -60,7 +50,7 @@ def test_to_graph_should_return_title_and_no_identifier() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        [ a modelldcatno:ModelElement ;
+        [ a modelldcatno:ObjectType ;
             dct:title   "Title 1"@en, "Tittel 1"@nb ;
         ]
         .
@@ -73,7 +63,7 @@ def test_to_graph_should_return_title_and_no_identifier() -> None:
 
 def test_to_graph_should_return_dct_identifier_as_graph() -> None:
     """It returns a dct_identifier graph isomorphic to spec."""
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     modelelement.dct_identifier = "123456789"
 
@@ -84,7 +74,7 @@ def test_to_graph_should_return_dct_identifier_as_graph() -> None:
     @prefix dcat: <http://www.w3.org/ns/dcat#> .
     @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-    <http://example.com/modelelements/1>    a modelldcatno:ModelElement ;
+    <http://example.com/modelelements/1>    a modelldcatno:ObjectType ;
         dct:identifier "123456789";
     .
     """
@@ -96,7 +86,7 @@ def test_to_graph_should_return_dct_identifier_as_graph() -> None:
 
 def test_to_graph_should_return_subject() -> None:
     """It returns a subject graph isomorphic to spec."""
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     subject = Concept()
     subject.identifier = "https://example.com/subjects/1"
@@ -110,7 +100,7 @@ def test_to_graph_should_return_subject() -> None:
     @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
     @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
-    <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
+    <http://example.com/modelelements/1> a modelldcatno:ObjectType ;
         dct:subject <https://example.com/subjects/1> ;
     .
      <https://example.com/subjects/1> a skos:Concept .
@@ -124,7 +114,7 @@ def test_to_graph_should_return_subject() -> None:
 
 def test_to_graph_should_return_has_property_both_identifiers() -> None:
     """It returns a has_property graph isomorphic to spec."""
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
 
     modelproperty = ModelProperty()
@@ -141,7 +131,7 @@ def test_to_graph_should_return_has_property_both_identifiers() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType ;
         modelldcatno:hasProperty <http://example.com/properties/1> .
 
         <http://example.com/properties/1> a modelldcatno:Property ;
@@ -156,7 +146,7 @@ def test_to_graph_should_return_has_property_both_identifiers() -> None:
 
 def test_to_graph_should_return_has_property_bnode_modelelement_id() -> None:
     """It returns a has_property graph isomorphic to spec."""
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
 
     modelproperty = ModelProperty()
@@ -169,7 +159,7 @@ def test_to_graph_should_return_has_property_bnode_modelelement_id() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType ;
             modelldcatno:hasProperty [ a modelldcatno:Property ] .
 
         """
@@ -181,7 +171,7 @@ def test_to_graph_should_return_has_property_bnode_modelelement_id() -> None:
 
 def test_to_graph_should_return_has_property_bnode_modelproperty_id() -> None:
     """It returns a has_property graph isomorphic to spec."""
-    modelelement = ModelElement()
+    modelelement = ObjectType()
 
     modelproperty = ModelProperty()
     modelproperty.identifier = "http://example.com/properties/1"
@@ -194,7 +184,7 @@ def test_to_graph_should_return_has_property_bnode_modelproperty_id() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        [ a modelldcatno:ModelElement ;
+        [ a modelldcatno:ObjectType ;
             modelldcatno:hasProperty <http://example.com/properties/1>
         ] .
 
@@ -209,7 +199,7 @@ def test_to_graph_should_return_has_property_bnode_modelproperty_id() -> None:
 
 def test_to_graph_should_return_has_property_blank_nodes() -> None:
     """It returns a has_property graph isomorphic to spec."""
-    modelelement = ModelElement()
+    modelelement = ObjectType()
 
     modelproperty = ModelProperty()
     modelelement.has_property.append(modelproperty)
@@ -221,7 +211,7 @@ def test_to_graph_should_return_has_property_blank_nodes() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        [ a modelldcatno:ModelElement ;
+        [ a modelldcatno:ObjectType ;
             modelldcatno:hasProperty [ a modelldcatno:Property ]
         ] .
         """

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -5,8 +5,7 @@ from concepttordf import Concept
 import pytest
 from rdflib import Graph
 
-from modelldcatnotordf.modelldcatno import ModelElement
-from modelldcatnotordf.modelldcatno import ModelProperty
+from modelldcatnotordf.modelldcatno import ModelElement, ModelProperty, ObjectType
 from tests.testutils import assert_isomorphic
 
 """
@@ -69,11 +68,10 @@ def test_to_graph_should_return_has_type_both_identifiers() -> None:
     property = ModelProperty()
     property.identifier = "http://example.com/properties/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
 
-    has_types: List[ModelElement] = []
-    has_types.append(modelelement)
+    has_types: List[ModelElement] = [modelelement]
     property.has_type = has_types
 
     src = """
@@ -86,7 +84,7 @@ def test_to_graph_should_return_has_type_both_identifiers() -> None:
         <http://example.com/properties/1> a modelldcatno:Property ;
         modelldcatno:hasType <http://example.com/modelelements/1> .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType ;
 
         .
         """
@@ -101,7 +99,7 @@ def test_to_graph_should_return_has_type_blank_node_property_identifier() -> Non
     property = ModelProperty()
     property.identifier = "http://example.com/properties/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     property.has_type.append(modelelement)
 
     src = """
@@ -112,7 +110,7 @@ def test_to_graph_should_return_has_type_blank_node_property_identifier() -> Non
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         <http://example.com/properties/1> a modelldcatno:Property ;
-            modelldcatno:hasType [ a modelldcatno:ModelElement ] .
+            modelldcatno:hasType [ a modelldcatno:ObjectType ] .
 
         """
     g1 = Graph().parse(data=property.to_rdf(), format="turtle")
@@ -125,7 +123,7 @@ def test_to_graph_should_return_has_type_blank_node_modelelement_identifier() ->
     """It returns a has_type graph isomorphic to spec."""
     property = ModelProperty()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     property.has_type.append(modelelement)
 
@@ -140,7 +138,7 @@ def test_to_graph_should_return_has_type_blank_node_modelelement_identifier() ->
             modelldcatno:hasType <http://example.com/modelelements/1>
         ] .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement .
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType .
 
         """
     g1 = Graph().parse(data=property.to_rdf(), format="turtle")
@@ -153,7 +151,7 @@ def test_to_graph_should_return_has_type_blank_nodes() -> None:
     """It returns a has_type graph isomorphic to spec."""
     property = ModelProperty()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     property.has_type.append(modelelement)
 
     src = """
@@ -164,7 +162,7 @@ def test_to_graph_should_return_has_type_blank_nodes() -> None:
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         [ a modelldcatno:Property ;
-            modelldcatno:hasType [ a modelldcatno:ModelElement ]
+            modelldcatno:hasType [ a modelldcatno:ObjectType ]
         ] .
         """
     g1 = Graph().parse(data=property.to_rdf(), format="turtle")

--- a/tests/test_realization.py
+++ b/tests/test_realization.py
@@ -3,7 +3,7 @@
 import pytest
 from rdflib import Graph
 
-from modelldcatnotordf.modelldcatno import ModelElement, Realization
+from modelldcatnotordf.modelldcatno import ObjectType, Realization
 from tests.testutils import assert_isomorphic
 
 """
@@ -66,7 +66,7 @@ def test_to_graph_should_return_has_supplier_both_identifiers() -> None:
     realization = Realization()
     realization.identifier = "http://example.com/realizations/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     realization.has_supplier = modelelement
 
@@ -80,7 +80,7 @@ def test_to_graph_should_return_has_supplier_both_identifiers() -> None:
         <http://example.com/realizations/1> a modelldcatno:Realization ;
             modelldcatno:hasSupplier <http://example.com/modelelements/1> .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType ;
 
         .
         """
@@ -95,7 +95,7 @@ def test_to_graph_should_return_has_supplier_bnode_realization_id() -> None:
     realization = Realization()
     realization.identifier = "http://example.com/realizations/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     realization.has_supplier = modelelement
 
     src = """
@@ -106,7 +106,7 @@ def test_to_graph_should_return_has_supplier_bnode_realization_id() -> None:
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         <http://example.com/realizations/1> a modelldcatno:Realization ;
-            modelldcatno:hasSupplier [ a modelldcatno:ModelElement ] .
+            modelldcatno:hasSupplier [ a modelldcatno:ObjectType ] .
 
         """
     g1 = Graph().parse(data=realization.to_rdf(), format="turtle")
@@ -119,7 +119,7 @@ def test_to_graph_should_return_has_supplier_bnode_modelelement_id() -> None:
     """It returns a has_supplier graph isomorphic to spec."""
     realization = Realization()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     realization.has_supplier = modelelement
 
@@ -134,7 +134,7 @@ def test_to_graph_should_return_has_supplier_bnode_modelelement_id() -> None:
             modelldcatno:hasSupplier <http://example.com/modelelements/1>
         ] .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement .
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType .
 
         """
     g1 = Graph().parse(data=realization.to_rdf(), format="turtle")
@@ -147,7 +147,7 @@ def test_to_graph_should_return_has_supplier_blank_nodes() -> None:
     """It returns a has_supplier graph isomorphic to spec."""
     realization = Realization()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     realization.has_supplier = modelelement
 
     src = """
@@ -158,7 +158,7 @@ def test_to_graph_should_return_has_supplier_blank_nodes() -> None:
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         [ a modelldcatno:Realization ;
-            modelldcatno:hasSupplier [ a modelldcatno:ModelElement ]
+            modelldcatno:hasSupplier [ a modelldcatno:ObjectType ]
         ] .
         """
     g1 = Graph().parse(data=realization.to_rdf(), format="turtle")

--- a/tests/test_specialization.py
+++ b/tests/test_specialization.py
@@ -3,7 +3,7 @@
 import pytest
 from rdflib import Graph
 
-from modelldcatnotordf.modelldcatno import ModelElement, Specialization
+from modelldcatnotordf.modelldcatno import ObjectType, Specialization
 from tests.testutils import assert_isomorphic
 
 """
@@ -66,7 +66,7 @@ def test_to_graph_should_return_has_general_concept_both_identifiers() -> None:
     specialization = Specialization()
     specialization.identifier = "http://example.com/specializations/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     specialization.has_general_concept = modelelement
 
@@ -80,7 +80,7 @@ def test_to_graph_should_return_has_general_concept_both_identifiers() -> None:
         <http://example.com/specializations/1> a modelldcatno:Specialization ;
             modelldcatno:hasGeneralConcept <http://example.com/modelelements/1> .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement ;
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType ;
 
         .
         """
@@ -95,7 +95,7 @@ def test_to_graph_should_return_has_general_concept_bnode_specialization_id() ->
     specialization = Specialization()
     specialization.identifier = "http://example.com/specializations/1"
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     specialization.has_general_concept = modelelement
 
     src = """
@@ -106,7 +106,7 @@ def test_to_graph_should_return_has_general_concept_bnode_specialization_id() ->
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         <http://example.com/specializations/1> a modelldcatno:Specialization ;
-            modelldcatno:hasGeneralConcept [ a modelldcatno:ModelElement ] .
+            modelldcatno:hasGeneralConcept [ a modelldcatno:ObjectType ] .
 
         """
     g1 = Graph().parse(data=specialization.to_rdf(), format="turtle")
@@ -119,7 +119,7 @@ def test_to_graph_should_return_has_general_concept_bnode_modelelement_id() -> N
     """It returns a has_general_concept graph isomorphic to spec."""
     specialization = Specialization()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
     specialization.has_general_concept = modelelement
 
@@ -134,7 +134,7 @@ def test_to_graph_should_return_has_general_concept_bnode_modelelement_id() -> N
             modelldcatno:hasGeneralConcept <http://example.com/modelelements/1>
         ] .
 
-        <http://example.com/modelelements/1> a modelldcatno:ModelElement .
+        <http://example.com/modelelements/1> a modelldcatno:ObjectType .
 
         """
     g1 = Graph().parse(data=specialization.to_rdf(), format="turtle")
@@ -147,7 +147,7 @@ def test_to_graph_should_return_has_general_concept_blank_nodes() -> None:
     """It returns a has_general_concept graph isomorphic to spec."""
     specialization = Specialization()
 
-    modelelement = ModelElement()
+    modelelement = ObjectType()
     specialization.has_general_concept = modelelement
 
     src = """
@@ -158,7 +158,7 @@ def test_to_graph_should_return_has_general_concept_blank_nodes() -> None:
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
         [ a modelldcatno:Specialization ;
-            modelldcatno:hasGeneralConcept [ a modelldcatno:ModelElement ]
+            modelldcatno:hasGeneralConcept [ a modelldcatno:ObjectType ]
         ] .
         """
     g1 = Graph().parse(data=specialization.to_rdf(), format="turtle")

--- a/tests/testintegration.py
+++ b/tests/testintegration.py
@@ -2,7 +2,7 @@
 
 from rdflib import Graph
 
-from modelldcatnotordf.modelldcatno import InformationModel, ModelElement
+from modelldcatnotordf.modelldcatno import InformationModel, ObjectType
 from modelldcatnotordf.modelldcatno import ModelProperty
 from tests.testutils import assert_isomorphic
 
@@ -14,7 +14,7 @@ Test cases for larger scale integration across classes.
 
 def test_title_should_be_set_on_correct_element() -> None:
     """It returns a information model graph isomorphic to spec."""
-    element = ModelElement()
+    element = ObjectType()
     element.identifier = "http://example.com/element"
     element.title = {"nb": "element"}
 
@@ -56,7 +56,7 @@ def test_title_should_be_set_on_correct_element() -> None:
         <http://example.com/egenskap2> a modelldcatno:Property ;
                 dct:title "egenskap2"@nb .
 
-        <http://example.com/element> a modelldcatno:ModelElement ;
+        <http://example.com/element> a modelldcatno:ObjectType ;
                 dct:title "element"@nb ;
                 modelldcatno:hasProperty <http://example.com/egenskap0>,
                                         <http://example.com/egenskap1>,


### PR DESCRIPTION
- Klassen ModelElement gjøres nå abstrakt
- MyPy kaster er en exception under kjøring dersom man forsøker å instansiere et objekt av klassen ModelElement