### PR TITLE
Noen flere optional/recommended felter på InformationModel

### DIFF
--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, List, Optional
 
-from concepttordf import Concept
+from concepttordf import Concept, Contact
 from datacatalogtordf import Agent, Resource, URI
 from rdflib import BNode, Graph, Literal, Namespace, RDF, URIRef
 
@@ -45,6 +45,7 @@ class InformationModel(Resource):
         "_has_part",
         "_is_part_of",
         "_homepage",
+        "_contactpoints",
     )
 
     _title: dict
@@ -58,6 +59,7 @@ class InformationModel(Resource):
     _has_part: List[InformationModel]
     _is_part_of: List[InformationModel]
     _homepage: URI
+    _contactpoints: List[Contact]
 
     def __init__(self) -> None:
         """Inits InformationModel object with default values."""
@@ -69,6 +71,7 @@ class InformationModel(Resource):
         self._is_replaced_by = []
         self._has_part = []
         self._is_part_of = []
+        self._contactpoints = []
 
     @property
     def informationmodelidentifier(self) -> str:
@@ -208,6 +211,15 @@ class InformationModel(Resource):
     def homepage(self: InformationModel, homepage: str) -> None:
         self._homepage = URI(homepage)
 
+    @property
+    def contactpoints(self: InformationModel) -> List[Contact]:
+        """Get/set for contactpoints."""
+        return self._contactpoints
+
+    @contactpoints.setter
+    def contactpoints(self: InformationModel, contactpoints: List[Contact]) -> None:
+        self._contactpoints = contactpoints
+
     def to_rdf(
         self: InformationModel,
         format: str = "turtle",
@@ -246,6 +258,7 @@ class InformationModel(Resource):
         self._has_part_to_graph()
         self._is_part_of_to_graph()
         self._homepage_to_graph()
+        self._contactpoints_to_graph()
 
         if getattr(self, "informationmodelidentifier", None):
             self._g.add(
@@ -398,6 +411,24 @@ class InformationModel(Resource):
     def _homepage_to_graph(self: InformationModel) -> None:
         if getattr(self, "homepage", None):
             self._g.add((URIRef(self.identifier), FOAF.homepage, URIRef(self.homepage)))
+
+    def _contactpoints_to_graph(self: InformationModel) -> None:
+        if getattr(self, "contactpoints", None):
+
+            for contactpoint in self._contactpoints:
+
+                _contactpoint = BNode()
+
+                for _s, p, o in contactpoint._to_graph().triples((None, None, None)):
+                    self._g.add((_contactpoint, p, o))
+
+                self._g.add(
+                    (
+                        URIRef(self.identifier),
+                        DCAT.contactPoint,
+                        _contactpoint,
+                    )
+                )
 
 
 class ModelElement(ABC):

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -44,6 +44,7 @@ class InformationModel(Resource):
         "_is_replaced_by",
         "_has_part",
         "_is_part_of",
+        "_homepage",
     )
 
     _title: dict
@@ -56,6 +57,7 @@ class InformationModel(Resource):
     _is_replaced_by: List[InformationModel]
     _has_part: List[InformationModel]
     _is_part_of: List[InformationModel]
+    _homepage: URI
 
     def __init__(self) -> None:
         """Inits InformationModel object with default values."""
@@ -197,6 +199,15 @@ class InformationModel(Resource):
         """Set for is_part_of."""
         self._is_part_of = is_part_of
 
+    @property
+    def homepage(self: InformationModel) -> str:
+        """Get/set for homepage."""
+        return self._homepage
+
+    @homepage.setter
+    def homepage(self: InformationModel, homepage: str) -> None:
+        self._homepage = URI(homepage)
+
     def to_rdf(
         self: InformationModel,
         format: str = "turtle",
@@ -234,6 +245,7 @@ class InformationModel(Resource):
         self._is_replaced_by_to_graph()
         self._has_part_to_graph()
         self._is_part_of_to_graph()
+        self._homepage_to_graph()
 
         if getattr(self, "informationmodelidentifier", None):
             self._g.add(
@@ -382,6 +394,10 @@ class InformationModel(Resource):
                         _is_part_of,
                     )
                 )
+
+    def _homepage_to_graph(self: InformationModel) -> None:
+        if getattr(self, "homepage", None):
+            self._g.add((URIRef(self.identifier), FOAF.homepage, URIRef(self.homepage)))
 
 
 class ModelElement(ABC):

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 from typing import Any, List, Optional
 
 from concepttordf import Concept, Contact
-from datacatalogtordf import Agent, Resource, URI
+from datacatalogtordf import Agent, Location, Resource, URI
 from rdflib import BNode, Graph, Literal, Namespace, RDF, URIRef
 
 from modelldcatnotordf.licensedocument import LicenseDocument
@@ -46,6 +46,7 @@ class InformationModel(Resource):
         "_is_part_of",
         "_homepage",
         "_contactpoints",
+        "_locations",
     )
 
     _title: dict
@@ -60,6 +61,7 @@ class InformationModel(Resource):
     _is_part_of: List[InformationModel]
     _homepage: URI
     _contactpoints: List[Contact]
+    _locations: List[Location]
 
     def __init__(self) -> None:
         """Inits InformationModel object with default values."""
@@ -72,6 +74,7 @@ class InformationModel(Resource):
         self._has_part = []
         self._is_part_of = []
         self._contactpoints = []
+        self._locations = []
 
     @property
     def informationmodelidentifier(self) -> str:
@@ -220,6 +223,15 @@ class InformationModel(Resource):
     def contactpoints(self: InformationModel, contactpoints: List[Contact]) -> None:
         self._contactpoints = contactpoints
 
+    @property
+    def locations(self: InformationModel) -> List[Location]:
+        """Get/set for locations."""
+        return self._locations
+
+    @locations.setter
+    def locations(self: InformationModel, locations: List[Location]) -> None:
+        self._locations = locations
+
     def to_rdf(
         self: InformationModel,
         format: str = "turtle",
@@ -259,6 +271,7 @@ class InformationModel(Resource):
         self._is_part_of_to_graph()
         self._homepage_to_graph()
         self._contactpoints_to_graph()
+        self._locations_to_graph()
 
         if getattr(self, "informationmodelidentifier", None):
             self._g.add(
@@ -427,6 +440,24 @@ class InformationModel(Resource):
                         URIRef(self.identifier),
                         DCAT.contactPoint,
                         _contactpoint,
+                    )
+                )
+
+    def _locations_to_graph(self: InformationModel) -> None:
+        if getattr(self, "locations", None):
+
+            for location in self._locations:
+
+                _location = BNode()
+
+                for _s, p, o in location._to_graph().triples((None, None, None)):
+                    self._g.add((_location, p, o))
+
+                self._g.add(
+                    (
+                        URIRef(self.identifier),
+                        DCT.spatial,
+                        _location,
                     )
                 )
 

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -2,7 +2,7 @@
 from typing import List
 
 from concepttordf import Concept, Contact
-from datacatalogtordf import Agent
+from datacatalogtordf import Agent, Location
 import pytest
 from rdflib import Graph, Namespace
 
@@ -711,6 +711,40 @@ def test_to_graph_should_return_contactpoint() -> None:
                                vcard:hasTelephone <tel:12345678> ;
                               ] ;
         .
+    """
+    g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)
+
+
+def test_to_graph_should_return_centroid_as_graph() -> None:
+    """It returns a centroid graph isomorphic to spec."""
+    location = Location()
+    location.identifier = "http://example.com/locations/1"
+    location.centroid = "POINT(4.88412 52.37509)"
+    informationmodel = InformationModel()
+    informationmodel.identifier = "http://example.com/informationmodels/1"
+    informationmodel.locations = [location]
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix locn: <http://www.w3.org/ns/locn#> .
+    @prefix geosparql: <http://www.opengis.net/ont/geosparql#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+    @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+    @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+    @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+
+    <http://example.com/informationmodels/1> a modelldcatno:InformationModel ;
+        dct:spatial [
+                    a dct:Location ;
+                      dcat:centroid \"POINT(4.88412 52.37509)\"^^geosparql:asWKT ]
+
+    .
     """
     g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
     g2 = Graph().parse(data=src, format="turtle")

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -647,3 +647,30 @@ def test_to_graph_should_return_keyword() -> None:
     g2 = Graph().parse(data=src, format="turtle")
 
     assert_isomorphic(g1, g2)
+
+
+def test_to_graph_should_return_release_date() -> None:
+    """It returns a issued graph isomorphic to spec."""
+    informationmodel = InformationModel()
+    informationmodel.identifier = "http://example.com/informationmodels/1"
+    informationmodel.release_date = "2020-03-24"
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcat: <https://data.norge.no/vocabulary/modelldcatno#> .
+    @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+
+    @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+
+    <http://example.com/informationmodels/1> a modelldcat:InformationModel ;
+        dct:issued   "2020-03-24"^^xsd:date ;
+        .
+    """
+
+    g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -1,7 +1,7 @@
 """Test cases for the informationmodel module."""
 from typing import List
 
-from concepttordf import Concept
+from concepttordf import Concept, Contact
 from datacatalogtordf import Agent
 import pytest
 from rdflib import Graph, Namespace
@@ -662,7 +662,6 @@ def test_to_graph_should_return_release_date() -> None:
     @prefix dcat: <http://www.w3.org/ns/dcat#> .
     @prefix modelldcat: <https://data.norge.no/vocabulary/modelldcatno#> .
     @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
-
     @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 
     <http://example.com/informationmodels/1> a modelldcat:InformationModel ;
@@ -670,6 +669,49 @@ def test_to_graph_should_return_release_date() -> None:
         .
     """
 
+    g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)
+
+
+def test_to_graph_should_return_contactpoint() -> None:
+    """It returns a contactpoint graph isomorphic to spec."""
+    informationmodel = InformationModel()
+    informationmodel.identifier = "http://example.com/informationmodels/1"
+    # Create contact:
+    contact = Contact()
+    contact.name = {
+        "en": "Norwegian Digitalisation Agency",
+        "nb": "Digitaliseringsdirektoratet",
+    }
+    contact.email = "sbd@example.com"
+    contact.url = "https://digdir.no"
+    contact.telephone = "12345678"
+    # Set the contactpoint to new contact:
+    informationmodel.contactpoints = [contact]
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+    @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+    @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+    @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+
+    <http://example.com/informationmodels/1> a modelldcatno:InformationModel ;
+        dcat:contactPoint    [ a               vcard:Organization ;
+                               vcard:hasEmail  <mailto:sbd@example.com> ;
+                               vcard:hasOrganizationName
+                                        "Norwegian Digitalisation Agency"@en,
+                                        "Digitaliseringsdirektoratet"@nb ;
+                               vcard:hasURL <https://digdir.no> ;
+                               vcard:hasTelephone <tel:12345678> ;
+                              ] ;
+        .
+    """
     g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
     g2 = Graph().parse(data=src, format="turtle")
 

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -571,3 +571,30 @@ def test_to_graph_should_return_is_part_of() -> None:
     g2 = Graph().parse(data=src, format="turtle")
 
     assert_isomorphic(g1, g2)
+
+
+def test_to_graph_should_return_language() -> None:
+    """It returns a language graph isomorphic to spec."""
+    """It returns an identifier graph isomorphic to spec."""
+    informationmodel = InformationModel()
+    informationmodel.identifier = "http://example.com/informationmodels/1"
+
+    informationmodel.language.append("http://id.loc.gov/vocabulary/iso639-1/en")
+    informationmodel.language.append("http://id.loc.gov/vocabulary/iso639-1/nb")
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+    <http://example.com/informationmodels/1> a modelldcatno:InformationModel ;
+                dct:language    <http://id.loc.gov/vocabulary/iso639-1/en> ,
+                                <http://id.loc.gov/vocabulary/iso639-1/nb> ;
+    .
+    """
+    g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -598,3 +598,27 @@ def test_to_graph_should_return_language() -> None:
     g2 = Graph().parse(data=src, format="turtle")
 
     assert_isomorphic(g1, g2)
+
+
+def test_to_graph_should_return_homepage() -> None:
+    """It returns a homepage graph isomorphic to spec."""
+    infomationmodel = InformationModel()
+    infomationmodel.identifier = "http://example.com/informationmodels/1"
+    infomationmodel.homepage = "http://example.org/informationmodel"
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+    @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+
+    <http://example.com/informationmodels/1> a modelldcatno:InformationModel ;
+        foaf:homepage <http://example.org/informationmodel> ;
+    .
+    """
+    g1 = Graph().parse(data=infomationmodel.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -622,3 +622,28 @@ def test_to_graph_should_return_homepage() -> None:
     g2 = Graph().parse(data=src, format="turtle")
 
     assert_isomorphic(g1, g2)
+
+
+def test_to_graph_should_return_keyword() -> None:
+    """It returns a keyword graph isomorphic to spec."""
+    informationmodel = InformationModel()
+    informationmodel.identifier = "http://example.com/informationmodels/1"
+    _keyword = {"nb": "Etnøkkelord", "nn": "Eitnøkkelord", "en": "Akeyword"}
+    informationmodel.keyword = _keyword
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcat: <https://data.norge.no/vocabulary/modelldcatno#> .
+    @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+
+    <http://example.com/informationmodels/1> a modelldcat:InformationModel ;
+        dcat:keyword   "Akeyword"@en, "Etnøkkelord"@nb, "Eitnøkkelord"@nn ;
+        .
+    """
+    g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)


### PR DESCRIPTION

- Noe av dette finnes i dcat, men f.eks homepage finnes ikke på dcat:Resource som InformationModel er subklasse av.

- På dcat:Resource finnes contactpoint og location, men i modelldcatapno skal man altså kunne ha støtte for en liste av disse feltene. 

