### PR TITLE
feat: #4 dct:format on foaf:Document

### DIFF
--- a/src/modelldcatnotordf/document.py
+++ b/src/modelldcatnotordf/document.py
@@ -1,0 +1,111 @@
+"""Document module for mapping a document to rdf.
+
+This module contains methods for mapping a document object to rdf
+according to the
+`dcat-ap-no v.2 standard <https://doc.difi.no/review/dcat-ap-no/#klasse-distribusjon>`__
+
+Example:
+    >>> from datacatalogtordf import Document
+    >>> # Create a document:
+    >>> document = Document()
+    >>> document.identifier = "http://example.com/documents/1"
+    >>> document.title = {"en": "The Python Language Reference Manual"}
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from datacatalogtordf import Document
+from datacatalogtordf.uri import URI
+from rdflib import BNode, DCTERMS, FOAF, Graph, Literal, Namespace, RDF, URIRef
+
+DCAT = Namespace("http://www.w3.org/ns/dcat#")
+
+
+class FoafDocument(Document):
+    """A class representing a foaf:Document.
+
+    Attributes:
+        identifier (URI): A URI uniquely identifying the document
+        title (dict): A title given to the document. key is langauge code
+        language (str): A reference to the language which is used in the document
+        format (str): A link to a concept designating the type of the document
+    """
+
+    slots = ("_identifier", "_title", "_language", "_format")
+
+    _identifier: URI
+    _title: dict
+    _language: str
+    _type: str
+    _format: str
+
+    def __init__(self) -> None:
+        """Inits an object with default values."""
+        self._type = FOAF.Document
+
+    @property
+    def format(self: Document) -> str:
+        """Get for format."""
+        return self._format
+
+    @format.setter
+    def format(self: Document, format: str) -> None:
+        """Set for format."""
+        self._format = URI(format)
+
+    def to_rdf(
+        self: Document, format: str = "turtle", encoding: Optional[str] = "utf-8"
+    ) -> bytes:
+        """Maps the document to rdf.
+
+        Args:
+            format: a valid format. Default: turtle
+            encoding: the encoding to serialize into
+
+        Returns:
+            a rdf serialization as a bytes literal according to format.
+        """
+        return self._to_graph().serialize(format=format, encoding=encoding)
+
+    def _to_graph(self: Document) -> Graph:
+
+        self._g = Graph()
+        self._g.bind("dct", DCTERMS)
+        self._g.bind("foaf", FOAF)
+
+        if getattr(self, "identifier", None):
+            _self = URIRef(self.identifier)
+        else:
+            _self = BNode()
+
+        self._g.add((_self, RDF.type, FOAF.Document))
+
+        if getattr(self, "title", None):
+            for key in self.title:
+                self._g.add(
+                    (
+                        _self,
+                        DCTERMS.title,
+                        Literal(self.title[key], lang=key),
+                    )
+                )
+        if getattr(self, "language", None):
+            self._g.add(
+                (
+                    _self,
+                    DCTERMS.language,
+                    Literal(self.language, datatype=DCTERMS.LinguisticSystem),
+                )
+            )
+
+        if getattr(self, "format", None):
+            self._g.add(
+                (
+                    _self,
+                    DCTERMS["format"],  # https://github.com/RDFLib/rdflib/issues/932
+                    Literal(self.format, datatype=DCTERMS.MediaType),
+                )
+            )
+
+        return self._g

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,0 +1,112 @@
+"""Test cases for the document module."""
+
+import pytest
+from rdflib import Graph
+
+from modelldcatnotordf.document import FoafDocument
+from tests.testutils import assert_isomorphic
+
+
+def test_instantiate_document() -> None:
+    """It does not raise an exception."""
+    try:
+        _ = FoafDocument()
+    except Exception:
+        pytest.fail("Unexpected Exception ..")
+
+
+def test_to_graph_should_return_title_and_identifier() -> None:
+    """It returns a title graph isomorphic to spec."""
+    """It returns an identifier graph isomorphic to spec."""
+
+    document = FoafDocument()
+    document.identifier = "http://example.com/documents/1"
+    document.title = {"nb": "Tittel 1", "en": "Title 1"}
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+        <http://example.com/documents/1> a foaf:Document;
+                dct:title   "Title 1"@en, "Tittel 1"@nb ;
+        .
+        """
+    g1 = Graph().parse(data=document.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)
+
+
+def test_to_graph_should_return_document_as_bnode() -> None:
+    """It returns a title graph isomorphic to spec."""
+    """It returns an identifier graph isomorphic to spec."""
+
+    document = FoafDocument()
+    document.title = {"nb": "Tittel 1", "en": "Title 1"}
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+        [ a foaf:Document;
+                dct:title   "Title 1"@en, "Tittel 1"@nb ; ]
+        .
+        """
+    g1 = Graph().parse(data=document.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)
+
+
+def test_to_graph_should_return_language() -> None:
+    """It returns an identifier graph isomorphic to spec."""
+    document = FoafDocument()
+    document.identifier = "http://example.com/documents/1"
+    document.language = "http://example.com/languages/1"
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+        <http://example.com/documents/1> a foaf:Document;
+                dct:language "http://example.com/languages/1"^^dct:LinguisticSystem
+        .
+        """
+    g1 = Graph().parse(data=document.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)
+
+
+def test_to_graph_should_return_format() -> None:
+    """It returns an identifier graph isomorphic to spec."""
+    document = FoafDocument()
+    document.identifier = "http://example.com/documents/1"
+    document.format = "https://www.iana.org/assignments/media-types/application/pdf"
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+    <http://example.com/documents/1> a foaf:Document;
+        dct:format
+        "https://www.iana.org/assignments/media-types/application/pdf"^^dct:MediaType
+        .
+    """
+
+    g1 = Graph().parse(data=document.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)


### PR DESCRIPTION
En liten PR der jeg tar i bruk og utvider foaf:Document som er definert i datacatalogtordf (Biblioteket til Stig)