### PR TITLE
Fix/correcting resource serialization

### DIFF
--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -72,7 +72,7 @@ class InformationModel(Resource):
     _title: dict
     _publisher: Agent
     _subject: List[Union[Concept, str]]
-    _modelelements: List[ModelElement]
+    _modelelements: List[Union[ModelElement, URI]]
     _informationmodelidentifier: str
     _licensedocument: LicenseDocument
     _replaces: List[InformationModel]
@@ -182,13 +182,13 @@ class InformationModel(Resource):
         self._subject = subject
 
     @property
-    def modelelements(self: InformationModel) -> List[ModelElement]:
+    def modelelements(self: InformationModel) -> List[Union[ModelElement, URI]]:
         """Get for modelelements."""
         return self._modelelements
 
     @modelelements.setter
     def modelelements(
-        self: InformationModel, modelelements: List[ModelElement]
+        self: InformationModel, modelelements: List[Union[ModelElement, URI]]
     ) -> None:
         """Set for modelelements."""
         self._modelelements = modelelements
@@ -449,18 +449,24 @@ class InformationModel(Resource):
 
             for modelelement in self._modelelements:
 
-                _modelelement = (
-                    URIRef(modelelement.identifier)
-                    if getattr(modelelement, "identifier", None)
-                    else BNode()
-                )
+                if isinstance(modelelement, ModelElement):
 
-                for _s, p, o in modelelement._to_graph().triples((None, None, None)):
-                    self._g.add(
-                        (_modelelement, p, o)
-                        if isinstance(_modelelement, BNode)
-                        else (_s, p, o)
+                    _modelelement = (
+                        URIRef(modelelement.identifier)
+                        if getattr(modelelement, "identifier", None)
+                        else BNode()
                     )
+                    for _s, p, o in modelelement._to_graph().triples(
+                        (None, None, None)
+                    ):
+                        self._g.add(
+                            (_modelelement, p, o)
+                            if isinstance(_modelelement, BNode)
+                            else (_s, p, o)
+                        )
+
+                elif isinstance(modelelement, str):
+                    _modelelement = URIRef(modelelement)
 
                 self._g.add(
                     (

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -71,7 +71,7 @@ class InformationModel(Resource):
 
     _title: dict
     _publisher: Agent
-    _subject: List[Concept]
+    _subject: List[Union[Concept, str]]
     _modelelements: List[ModelElement]
     _informationmodelidentifier: str
     _licensedocument: LicenseDocument
@@ -172,12 +172,12 @@ class InformationModel(Resource):
         self._publisher = publisher
 
     @property
-    def subject(self: InformationModel) -> List[Concept]:
+    def subject(self: InformationModel) -> List[Union[Concept, str]]:
         """Get for subject."""
         return self._subject
 
     @subject.setter
-    def subject(self: InformationModel, subject: List[Concept]) -> None:
+    def subject(self: InformationModel, subject: List[Union[Concept, str]]) -> None:
         """Set for subject."""
         self._subject = subject
 
@@ -425,10 +425,15 @@ class InformationModel(Resource):
 
             for subject in self._subject:
 
-                _subject = URIRef(subject.identifier)
+                _subject = (
+                    URIRef(subject.identifier)
+                    if isinstance(subject, Concept)
+                    else URIRef(subject)
+                )
 
-                for _s, p, o in subject._to_graph().triples((None, None, None)):
-                    self._g.add((_subject, p, o))
+                if isinstance(subject, Concept):
+                    for _s, p, o in subject._to_graph().triples((None, None, None)):
+                        self._g.add((_subject, p, o))
 
                 self._g.add(
                     (

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -74,7 +74,7 @@ class InformationModel(Resource):
     _subject: List[Union[Concept, URI]]
     _modelelements: List[Union[ModelElement, URI]]
     _informationmodelidentifier: str
-    _licensedocument: LicenseDocument
+    _licensedocument: Union[LicenseDocument, URI]
     _replaces: List[InformationModel]
     _is_replaced_by: List[InformationModel]
     _has_part: List[InformationModel]
@@ -122,12 +122,12 @@ class InformationModel(Resource):
         return self._type
 
     @property
-    def licensedocument(self) -> LicenseDocument:
+    def licensedocument(self) -> Union[LicenseDocument, URI]:
         """Get for license."""
         return self._licensedocument
 
     @licensedocument.setter
-    def licensedocument(self, licensedocument: LicenseDocument) -> None:
+    def licensedocument(self, licensedocument: Union[LicenseDocument, URI]) -> None:
         """Set for license."""
         self._licensedocument = licensedocument
 
@@ -480,20 +480,23 @@ class InformationModel(Resource):
 
         if getattr(self, "licensedocument", None):
 
-            _licensedocument = (
-                URIRef(self.licensedocument.identifier)
-                if getattr(self.licensedocument, "identifier", None)
-                else BNode()
-            )
-
-            for _s, p, o in self.licensedocument._to_graph().triples(
-                (None, None, None)
-            ):
-                self._g.add(
-                    (_licensedocument, p, o)
-                    if isinstance(_licensedocument, BNode)
-                    else (_s, p, o)
+            if isinstance(self.licensedocument, LicenseDocument):
+                _licensedocument = (
+                    URIRef(self.licensedocument.identifier)
+                    if getattr(self.licensedocument, "identifier", None)
+                    else BNode()
                 )
+
+                for _s, p, o in self.licensedocument._to_graph().triples(
+                    (None, None, None)
+                ):
+                    self._g.add(
+                        (_licensedocument, p, o)
+                        if isinstance(_licensedocument, BNode)
+                        else (_s, p, o)
+                    )
+            elif isinstance(self.licensedocument, str):
+                _licensedocument = URIRef(self.licensedocument)
 
             self._g.add((URIRef(self.identifier), DCTERMS.license, _licensedocument))
 

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -71,7 +71,7 @@ class InformationModel(Resource):
 
     _title: dict
     _publisher: Agent
-    _subject: List[Union[Concept, str]]
+    _subject: List[Union[Concept, URI]]
     _modelelements: List[Union[ModelElement, URI]]
     _informationmodelidentifier: str
     _licensedocument: LicenseDocument
@@ -172,12 +172,12 @@ class InformationModel(Resource):
         self._publisher = publisher
 
     @property
-    def subject(self: InformationModel) -> List[Union[Concept, str]]:
+    def subject(self: InformationModel) -> List[Union[Concept, URI]]:
         """Get for subject."""
         return self._subject
 
     @subject.setter
-    def subject(self: InformationModel, subject: List[Union[Concept, str]]) -> None:
+    def subject(self: InformationModel, subject: List[Union[Concept, URI]]) -> None:
         """Set for subject."""
         self._subject = subject
 

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -196,7 +196,7 @@ def test_to_graph_should_return_contains_model_element() -> None:
     modelelement.identifier = "http://example.com/modelelements/1"
     modelelement.title = {"nb": "Tittel 1", "en": "Title 1"}
 
-    modelelements: List[ModelElement] = [modelelement]
+    modelelements: List[Union[ModelElement, str]] = [modelelement]
     informationmodel.modelelements = modelelements
 
     src = """
@@ -1060,6 +1060,50 @@ def test_to_graph_should_return_subject_as_uri() -> None:
 
         <https://example.com/subjects/3> a skos:Concept .
 
+        """
+
+    g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)
+
+
+def test_to_graph_should_return_modelelement_as_uri() -> None:
+    """It returns a information model graph isomorphic to spec."""
+    """It returns an modelelement graph isomorphic to spec."""
+
+    informationmodel = InformationModel()
+    informationmodel.identifier = "http://example.com/informationmodels/1"
+
+    modelelements: List[Union[ModelElement, str]] = []
+
+    modelelement1 = "https://example.com/modelelements/1"
+    modelelements.append(modelelement1)
+
+    modelelement2 = "https://example.com/modelelements/2"
+    modelelements.append(modelelement2)
+
+    modelelement3 = ObjectType()
+    modelelement3.identifier = "https://example.com/modelelements/3"
+    modelelements.append(modelelement3)
+
+    informationmodel.modelelements = modelelements
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+        @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+        <http://example.com/informationmodels/1>
+            a modelldcatno:InformationModel ;
+            modelldcatno:containsModelElement <https://example.com/modelelements/1> ;
+            modelldcatno:containsModelElement <https://example.com/modelelements/2> ;
+            modelldcatno:containsModelElement <https://example.com/modelelements/3> ;
+        .
+        <https://example.com/modelelements/3> a modelldcatno:ObjectType .
         """
 
     g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -1110,3 +1110,31 @@ def test_to_graph_should_return_modelelement_as_uri() -> None:
     g2 = Graph().parse(data=src, format="turtle")
 
     assert_isomorphic(g1, g2)
+
+
+def test_to_graph_should_return_licensedocument_as_uri() -> None:
+    """It returns a information model graph isomorphic to spec."""
+    """It returns an licensedocument graph isomorphic to spec."""
+    informationmodel = InformationModel()
+    informationmodel.identifier = "http://example.com/informationmodels/1"
+
+    informationmodel.licensedocument = "https://example.com/licensedocuments/1"
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+        @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+        <http://example.com/informationmodels/1>
+            a modelldcatno:InformationModel ;
+            dct:license <https://example.com/licensedocuments/1> ;
+           .
+        """
+
+    g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -1,5 +1,5 @@
 """Test cases for the informationmodel module."""
-from typing import List
+from typing import List, Union
 
 from concepttordf import Concept, Contact
 from datacatalogtordf import Agent, Location, PeriodOfTime
@@ -1014,6 +1014,53 @@ def test_to_graph_should_return_temporal() -> None:
             dcat:startDate "2019-12-31"^^xsd:date ]
     .
     """
+
+    g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)
+
+
+def test_to_graph_should_return_subject_as_uri() -> None:
+    """It returns a information model graph isomorphic to spec."""
+    """It returns an subject graph isomorphic to spec."""
+
+    informationmodel = InformationModel()
+    informationmodel.identifier = "http://example.com/informationmodels/1"
+
+    subjects: List[Union[Concept, str]] = []
+
+    subject1 = "https://example.com/subjects/1"
+    subjects.append(subject1)
+
+    subject2 = "https://example.com/subjects/2"
+    subjects.append(subject2)
+
+    subject3 = Concept()
+    subject3.identifier = "https://example.com/subjects/3"
+    subjects.append(subject3)
+
+    informationmodel.subject = subjects
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+        @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+        <http://example.com/informationmodels/1>
+            a modelldcatno:InformationModel ;
+            dct:subject <https://example.com/subjects/1> ;
+            dct:subject <https://example.com/subjects/2> ;
+            dct:subject <https://example.com/subjects/3> ;
+        .
+
+        <https://example.com/subjects/3> a skos:Concept .
+
+        """
 
     g1 = Graph().parse(data=informationmodel.to_rdf(), format="turtle")
     g2 = Graph().parse(data=src, format="turtle")


### PR DESCRIPTION
"Proof-of-concept" for endring med serialisering av ressurser som er object properties. 

Foreløpig er det for 

- dct:subject 
- modelldcatno:containsModelElement
- dct:license

Alle sammen på klassen InformationModel. 

Si i fra hvis noe skal være anderledes! Viktig at jeg ikke gjør feil endringer nå videre da det vil bli en del å rette på. :-) Legg ellers merke til at jeg ikke trengte å endre noen av testene. Så dette er bakover-kompatibelt. Men jeg måtte selvfølgelig legge til nye tester for tilfellene der ressursen er en uri. Dette må jeg gjøre med alle feltene fremover.

Det kommer nok en del PR'er på dette