### PR TITLE
Fix/skolemisering poc

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -17,3 +17,7 @@ ignore_missing_imports = True
 
 [mypy-nox_poetry.*]
 ignore_missing_imports = True
+
+[mypy-pytest_mock.*]
+ignore_missing_imports = True
+

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,7 +18,7 @@ python-versions = "*"
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -26,7 +26,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "attrs"
 version = "20.3.0"
 description = "Classes Without Boilerplate"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -122,7 +122,7 @@ requests = ">=2.7.9"
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -417,7 +417,7 @@ python-versions = "*"
 name = "more-itertools"
 version = "8.6.0"
 description = "More routines for operating on iterables, beyond itertools"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5"
 
@@ -481,7 +481,7 @@ python-versions = "*"
 name = "packaging"
 version = "20.9"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -519,7 +519,7 @@ flake8-polyfill = ">=1.0.2,<2"
 name = "pluggy"
 version = "0.13.1"
 description = "plugin and hook calling mechanisms for python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -533,7 +533,7 @@ dev = ["pre-commit", "tox"]
 name = "py"
 version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -584,7 +584,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "pytest"
 version = "5.4.3"
 description = "pytest: simple powerful testing with Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5"
 
@@ -617,6 +617,20 @@ pytest = ">=4.6"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "pytest-mock"
+version = "3.5.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
 
 [[package]]
 name = "pytype"
@@ -928,7 +942,7 @@ test = ["pytest (>=2.2.3)", "flake8 (>=2.4.0)", "isort (>=4.2.2)"]
 name = "wcwidth"
 version = "0.2.5"
 description = "Measures the displayed width of unicode strings in a terminal"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -968,7 +982,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "0e4fd5537aebbdbb3ccca4adaf763083d04860c1353f848f5757fa3c6cc1b3b5"
+content-hash = "5267309a891e71a4e11d481742a81e3b800d842a9aebb5b7a3684b7a3e499cad"
 
 [metadata.files]
 alabaster = [
@@ -1287,6 +1301,10 @@ pytest = [
 pytest-cov = [
     {file = "pytest-cov-2.11.1.tar.gz", hash = "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7"},
     {file = "pytest_cov-2.11.1-py2.py3-none-any.whl", hash = "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.5.1.tar.gz", hash = "sha256:a1e2aba6af9560d313c642dae7e00a2a12b022b80301d9d7fc8ec6858e1dd9fc"},
+    {file = "pytest_mock-3.5.1-py3-none-any.whl", hash = "sha256:379b391cfad22422ea2e252bdfc008edd08509029bcde3c25b2c0bd741e0424e"},
 ]
 pytype = [
     {file = "pytype-2020.12.23-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:aefea50cdc759efec3cfe401388fdf6b67347bf71e26e645d965db34a92c392f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ concepttordf = "^1.0.0"
 rdflib-jsonld = "^0.5.0"
 datacatalogtordf = "^1.2.0"
 validators = "^0.18.2"
+pytest-mock = "^3.5.1"
 
 
 [tool.poetry.dev-dependencies]

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -8,9 +8,7 @@ Refer to sub-class for typical usage examples.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-import os
 from typing import List, Optional, Union
-import uuid
 
 from concepttordf import Concept, Contact
 from datacatalogtordf import Agent, Location, Resource, URI
@@ -3223,71 +3221,3 @@ class Note(ModelProperty):
                         Literal(self.property_note[key], lang=key),
                     )
                 )
-
-
-class Skolemizer:
-    """A class for performing skolemization."""
-
-    skolemization: dict = {}
-    baseurl_key = "modelldcatno_baseurl"
-    baseurl_default_value = "http://wwww.digdir.no/"
-
-    @staticmethod
-    def is_exact_skolemization(skolemization: URI) -> bool:
-        """Returns true if the URI is a skolemization that exists in the model."""
-        return skolemization in Skolemizer.skolemization
-
-    @staticmethod
-    def has_skolemization_morfologi(skolemization: URI) -> bool:
-        """Checks if the URI complies to a skolemized form.
-
-        Args:
-            skolemization (URI): the URI to check.
-
-        Returns:
-            True if URI complies to skolemized form.
-        """
-        if not Skolemizer._is_valid_uri(skolemization):
-            return False
-
-        return skolemization.startswith(
-            Skolemizer.get_baseurl() + ".well-known/skolem/"
-        )
-
-    @staticmethod
-    def add_skolemization() -> URI:
-        """Creates a skolemization for the given classtype."""
-        _skolemization = (
-            Skolemizer.get_baseurl() + ".well-known/skolem/" + str(uuid.uuid4())
-        )
-
-        Skolemizer.skolemization[_skolemization] = True
-
-        return _skolemization
-
-    @staticmethod
-    def get_baseurl() -> str:
-        """Returns baseurl for skolemization."""
-        _baseurl = (
-            os.environ[Skolemizer.baseurl_key]
-            if Skolemizer.baseurl_key in os.environ.keys()
-            else Skolemizer.baseurl_default_value
-        )
-
-        if not Skolemizer._is_valid_uri(_baseurl):
-            _baseurl = Skolemizer.baseurl_default_value
-
-        if not _baseurl.endswith("/"):
-            _baseurl = _baseurl + "/"
-
-        return _baseurl
-
-    @staticmethod
-    def _is_valid_uri(uri: str) -> bool:
-        """Perform basic validation of link."""
-        _invalid_uri_chars = '<>" {}|\\^`'
-
-        for c in _invalid_uri_chars:
-            if c in uri:
-                return False
-        return True

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -8,7 +8,7 @@ Refer to sub-class for typical usage examples.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 from concepttordf import Concept, Contact
 from datacatalogtordf import Agent, Location, Resource, URI
@@ -67,6 +67,8 @@ class InformationModel(Resource):
         "_creator",
         "_has_format",
         "_temporal",
+        "_classmap",
+        "_skolemization",
     )
 
     _title: dict
@@ -90,6 +92,8 @@ class InformationModel(Resource):
     _creator: str
     _has_format: List[Union[FoafDocument, str]]
     _temporal: List[PeriodOfTime]
+    _classmap: dict
+    _skolemization: dict
 
     def __init__(self) -> None:
         """Inits InformationModel object with default values."""
@@ -105,6 +109,8 @@ class InformationModel(Resource):
         self._locations = []
         self._has_format = []
         self._temporal = []
+        self._classmap = {}
+        self._skolemization = {}
 
     @property
     def informationmodelidentifier(self) -> str:
@@ -352,6 +358,26 @@ class InformationModel(Resource):
     def temporal(self: InformationModel, temporal: List[PeriodOfTime]) -> None:
         """Set for temporal."""
         self._temporal = temporal
+
+    def is_skolemization(self: InformationModel, skolemization: URI) -> bool:
+        """Returns true if the URI is a skolemization in the model."""
+        return skolemization in self._skolemization
+
+    def add_skolemization(self: InformationModel, classtype: Any) -> URI:
+        """Creates a skolemization for the given classtype."""
+        classname = classtype.__class__.__name__
+        _identifier = self.identifier
+        _counter = (
+            self._classmap[classname] if classname in self._classmap.keys() else 0
+        )
+        _counter = _counter + 1
+
+        _skolemization = str(_identifier) + str(classname) + "/" + str(_counter)
+
+        self._skolemization[_skolemization] = True
+        self._classmap[classname] = _counter
+
+        return _skolemization
 
     def to_rdf(
         self: InformationModel,

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from functools import reduce
 import inspect
+import os
 import re
 import sys
 from typing import Any, List, Optional, Union
-
 
 from concepttordf import Concept, Contact
 from datacatalogtordf import Agent, Location, Resource, URI
@@ -42,6 +42,9 @@ PROV = Namespace("http://www.w3.org/ns/prov#")
 MODELLDCATNO = Namespace("https://data.norge.no/vocabulary/modelldcatno#")
 XKOS = Namespace("http://rdf-vocabulary.ddialliance.org/xkos#")
 ADMS = Namespace("http://www.w3.org/ns/adms#")
+
+baseurl_key = "modelldcatno_baseurl"
+baseurl_default_value = "http://wwww.digdir.no/"
 
 
 class InformationModel(Resource):
@@ -387,7 +390,7 @@ class InformationModel(Resource):
         Returns:
             True if URI complies to skolemized form.
         """
-        match = re.search(r"" + self.identifier, skolemization)
+        match = re.search(r"" + InformationModel.get_baseurl(), skolemization)
         if not match:
             return False
         match = re.search(r"[\d]*$", skolemization)
@@ -409,12 +412,23 @@ class InformationModel(Resource):
         )
         _counter = _counter + 1
 
-        _skolemization = str(self.identifier) + str(_classname) + "/" + str(_counter)
+        _skolemization = (
+            InformationModel.get_baseurl() + str(_classname) + "/" + str(_counter)
+        )
 
         self._skolemization[_skolemization] = True
         self._classmap[_classname] = _counter
 
         return _skolemization
+
+    @staticmethod
+    def get_baseurl() -> str:
+        """Returns baseurl for skolemization."""
+        return (
+            os.environ[baseurl_key]
+            if baseurl_key in os.environ.keys()
+            else baseurl_default_value
+        )
 
     def to_rdf(
         self: InformationModel,

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -30,6 +30,7 @@ import validators
 
 from modelldcatnotordf.document import FoafDocument
 from modelldcatnotordf.licensedocument import LicenseDocument
+from modelldcatnotordf.skolemizer import Skolemizer
 
 DCAT = Namespace("http://www.w3.org/ns/dcat#")
 ODRL = Namespace("http://www.w3.org/ns/odrl/2/")
@@ -37,9 +38,6 @@ PROV = Namespace("http://www.w3.org/ns/prov#")
 MODELLDCATNO = Namespace("https://data.norge.no/vocabulary/modelldcatno#")
 XKOS = Namespace("http://rdf-vocabulary.ddialliance.org/xkos#")
 ADMS = Namespace("http://www.w3.org/ns/adms#")
-
-baseurl_key = "modelldcatno_baseurl"
-baseurl_default_value = "http://wwww.digdir.no/"
 
 
 class InformationModel(Resource):
@@ -1214,18 +1212,13 @@ class ModelProperty(ABC):
 
                 if isinstance(has_type, ModelElement):
 
-                    _has_type = (
-                        URIRef(has_type.identifier)
-                        if getattr(has_type, "identifier", None)
-                        else BNode()
-                    )
+                    if not getattr(has_type, "identifier", None):
+                        has_type.identifier = Skolemizer.add_skolemization()
+
+                    _has_type = URIRef(has_type.identifier)
 
                     for _s, p, o in has_type._to_graph().triples((None, None, None)):
-                        self._g.add(
-                            (_has_type, p, o)
-                            if isinstance(_has_type, BNode)
-                            else (_s, p, o)
-                        )
+                        self._g.add((_s, p, o))
 
                 elif isinstance(has_type, str):
                     _has_type = URIRef(has_type)
@@ -1361,9 +1354,10 @@ class Role(ModelProperty):
         Returns:
             the role graph
         """
-        _self = (
-            URIRef(self.identifier) if getattr(self, "identifier", None) else BNode()
-        )
+        if not getattr(self, "identifier", None):
+            self.identifier = Skolemizer.add_skolemization()
+
+        _self = URIRef(self.identifier)
 
         super(Role, self)._to_graph(MODELLDCATNO.Role, _self)
 
@@ -1376,20 +1370,16 @@ class Role(ModelProperty):
         if getattr(self, "has_object_type", None):
 
             if isinstance(self.has_object_type, ObjectType):
-                _has_object_type = (
-                    URIRef(self._has_object_type.identifier)
-                    if getattr(self._has_object_type, "identifier", None)
-                    else BNode()
-                )
+
+                if not getattr(self._has_object_type, "identifier", None):
+                    self._has_object_type.identifier = Skolemizer.add_skolemization()
+
+                _has_object_type = URIRef(self._has_object_type.identifier)
 
                 for _s, p, o in self._has_object_type._to_graph().triples(
                     (None, None, None)
                 ):
-                    self._g.add(
-                        (_has_object_type, p, o)
-                        if isinstance(_has_object_type, BNode)
-                        else (_s, p, o)
-                    )
+                    self._g.add((_s, p, o))
 
             elif isinstance(self.has_object_type, str):
                 _has_object_type = URIRef(self.has_object_type)
@@ -1437,9 +1427,9 @@ class ObjectType(ModelElement):
         Returns:
             the object type graph
         """
-        _self = (
-            URIRef(self.identifier) if getattr(self, "identifier", None) else BNode()
-        )
+        if not getattr(self, "identifier", None):
+            self.identifier = Skolemizer.add_skolemization()
+        _self = URIRef(self.identifier)
 
         super(ObjectType, self)._to_graph(MODELLDCATNO.ObjectType, _self)
 

--- a/src/modelldcatnotordf/skolemizer.py
+++ b/src/modelldcatnotordf/skolemizer.py
@@ -1,0 +1,73 @@
+"""Module for performing Skolemization on blank nodes."""
+import os
+import uuid
+
+from datacatalogtordf import URI
+
+
+class Skolemizer:
+    """A class for performing skolemization."""
+
+    skolemization: dict = {}
+    baseurl_key = "modelldcatno_baseurl"
+    baseurl_default_value = "http://wwww.digdir.no/"
+
+    @staticmethod
+    def is_exact_skolemization(skolemization: URI) -> bool:
+        """Returns true if the URI is a skolemization that exists in the model."""
+        return skolemization in Skolemizer.skolemization
+
+    @staticmethod
+    def has_skolemization_morfologi(skolemization: URI) -> bool:
+        """Checks if the URI complies to a skolemized form.
+
+        Args:
+            skolemization (URI): the URI to check.
+
+        Returns:
+            True if URI complies to skolemized form.
+        """
+        if not Skolemizer._is_valid_uri(skolemization):
+            return False
+
+        return skolemization.startswith(
+            Skolemizer.get_baseurl() + ".well-known/skolem/"
+        )
+
+    @staticmethod
+    def add_skolemization() -> URI:
+        """Creates a skolemization for the given classtype."""
+        _skolemization = (
+            Skolemizer.get_baseurl() + ".well-known/skolem/" + str(uuid.uuid4())
+        )
+
+        Skolemizer.skolemization[_skolemization] = True
+
+        return _skolemization
+
+    @staticmethod
+    def get_baseurl() -> str:
+        """Returns baseurl for skolemization."""
+        _baseurl = (
+            os.environ[Skolemizer.baseurl_key]
+            if Skolemizer.baseurl_key in os.environ.keys()
+            else Skolemizer.baseurl_default_value
+        )
+
+        if not Skolemizer._is_valid_uri(_baseurl):
+            _baseurl = Skolemizer.baseurl_default_value
+
+        if not _baseurl.endswith("/"):
+            _baseurl = _baseurl + "/"
+
+        return _baseurl
+
+    @staticmethod
+    def _is_valid_uri(uri: str) -> bool:
+        """Perform basic validation of link."""
+        _invalid_uri_chars = '<>" {}|\\^`'
+
+        for c in _invalid_uri_chars:
+            if c in uri:
+                return False
+        return True

--- a/src/modelldcatnotordf/skolemizer.py
+++ b/src/modelldcatnotordf/skolemizer.py
@@ -8,14 +8,14 @@ from datacatalogtordf import URI
 class Skolemizer:
     """A class for performing skolemization."""
 
-    skolemization: dict = {}
+    skolemizations: set = set()
     baseurl_key = "modelldcatno_baseurl"
     baseurl_default_value = "http://wwww.digdir.no/"
 
     @staticmethod
     def is_exact_skolemization(skolemization: URI) -> bool:
         """Returns true if the URI is a skolemization that exists in the model."""
-        return skolemization in Skolemizer.skolemization
+        return skolemization in Skolemizer.skolemizations
 
     @staticmethod
     def has_skolemization_morfologi(skolemization: URI) -> bool:
@@ -41,7 +41,7 @@ class Skolemizer:
             Skolemizer.get_baseurl() + ".well-known/skolem/" + str(uuid.uuid4())
         )
 
-        Skolemizer.skolemization[_skolemization] = True
+        Skolemizer.skolemizations.add(_skolemization)
 
         return _skolemization
 

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -1437,3 +1437,28 @@ def test_to_graph_should_return_has_format_as_uri() -> None:
     g2 = Graph().parse(data=src, format="turtle")
 
     assert_isomorphic(g1, g2)
+
+
+def test_add_skolemization() -> None:
+    """Tests skolemization."""
+    informationmodel = InformationModel()
+    informationmodel.identifier = (
+        "https://altinn-model-publisher.digdir.no/models/4985-5704/"
+    )
+
+    modelelement = ObjectType()
+
+    skolemization1 = (
+        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/1"
+    )
+
+    skolemization2 = (
+        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/2"
+    )
+
+    assert not informationmodel.is_skolemization(skolemization1)
+    assert skolemization1 == informationmodel.add_skolemization(modelelement)
+    assert informationmodel.is_skolemization(skolemization1)
+    assert not informationmodel.is_skolemization(skolemization2)
+    assert skolemization2 == informationmodel.add_skolemization(modelelement)
+    assert informationmodel.is_skolemization(skolemization2)

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -1456,9 +1456,61 @@ def test_add_skolemization() -> None:
         "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/2"
     )
 
-    assert not informationmodel.is_skolemization(skolemization1)
+    assert not informationmodel.is_exact_skolemization(skolemization1)
     assert skolemization1 == informationmodel.add_skolemization(modelelement)
-    assert informationmodel.is_skolemization(skolemization1)
-    assert not informationmodel.is_skolemization(skolemization2)
+    assert informationmodel.is_exact_skolemization(skolemization1)
+    assert not informationmodel.is_exact_skolemization(skolemization2)
     assert skolemization2 == informationmodel.add_skolemization(modelelement)
-    assert informationmodel.is_skolemization(skolemization2)
+    assert informationmodel.is_exact_skolemization(skolemization2)
+
+
+def test_has_skolemization_morfologi_success() -> None:
+    """Tests skolemization morfologi."""
+    informationmodel = InformationModel()
+    informationmodel.identifier = (
+        "https://altinn-model-publisher.digdir.no/models/4985-5704/"
+    )
+
+    _skolemization = (
+        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/2"
+    )
+
+    assert informationmodel.has_skolemization_morfologi(_skolemization)
+
+
+def test_has_skolemization_morfologi_incorrect_identifier() -> None:
+    """Tests skolemization morfologi."""
+    informationmodel = InformationModel()
+    informationmodel.identifier = (
+        "https://altinn-model-publisher.digdir.no/models/4985-5704/"
+    )
+
+    _skolemization = "https://someWrongIdentifier/ObjectType/2"
+
+    assert not informationmodel.has_skolemization_morfologi(_skolemization)
+
+
+def test_has_skolemization_morfologi_incorrect_counter() -> None:
+    """Tests skolemization morfologi."""
+    informationmodel = InformationModel()
+    informationmodel.identifier = (
+        "https://altinn-model-publisher.digdir.no/models/4985-5704/"
+    )
+
+    _skolemization = (
+        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/X"
+    )
+
+    assert not informationmodel.has_skolemization_morfologi(_skolemization)
+
+
+def test_has_skolemization_morfologi_incorrect_class() -> None:
+    """Tests skolemization morfologi."""
+    informationmodel = InformationModel()
+    informationmodel.identifier = (
+        "https://altinn-model-publisher.digdir.no/models/4985-5704/"
+    )
+
+    _skolemization = "https://altinn-model-publisher.digdir.no/models/4985-5704/Foo/1"
+
+    assert not informationmodel.has_skolemization_morfologi(_skolemization)

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -1,4 +1,5 @@
 """Test cases for the informationmodel module."""
+import os
 from typing import List, Union
 
 from concepttordf import Concept, Contact
@@ -8,7 +9,13 @@ from rdflib import Graph, Namespace
 
 from modelldcatnotordf.document import FoafDocument
 from modelldcatnotordf.licensedocument import LicenseDocument
-from modelldcatnotordf.modelldcatno import InformationModel, ModelElement, ObjectType
+from modelldcatnotordf.modelldcatno import (
+    baseurl_default_value,
+    baseurl_key,
+    InformationModel,
+    ModelElement,
+    ObjectType,
+)
 from tests.testutils import assert_isomorphic
 
 """
@@ -1442,9 +1449,9 @@ def test_to_graph_should_return_has_format_as_uri() -> None:
 def test_add_skolemization() -> None:
     """Tests skolemization."""
     informationmodel = InformationModel()
-    informationmodel.identifier = (
-        "https://altinn-model-publisher.digdir.no/models/4985-5704/"
-    )
+    os.environ[
+        baseurl_key
+    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
 
     modelelement = ObjectType()
 
@@ -1467,9 +1474,9 @@ def test_add_skolemization() -> None:
 def test_has_skolemization_morfologi_success() -> None:
     """Tests skolemization morfologi."""
     informationmodel = InformationModel()
-    informationmodel.identifier = (
-        "https://altinn-model-publisher.digdir.no/models/4985-5704/"
-    )
+    os.environ[
+        baseurl_key
+    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
 
     _skolemization = (
         "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/2"
@@ -1481,9 +1488,9 @@ def test_has_skolemization_morfologi_success() -> None:
 def test_has_skolemization_morfologi_incorrect_identifier() -> None:
     """Tests skolemization morfologi."""
     informationmodel = InformationModel()
-    informationmodel.identifier = (
-        "https://altinn-model-publisher.digdir.no/models/4985-5704/"
-    )
+    os.environ[
+        baseurl_key
+    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
 
     _skolemization = "https://someWrongIdentifier/ObjectType/2"
 
@@ -1493,9 +1500,9 @@ def test_has_skolemization_morfologi_incorrect_identifier() -> None:
 def test_has_skolemization_morfologi_incorrect_counter() -> None:
     """Tests skolemization morfologi."""
     informationmodel = InformationModel()
-    informationmodel.identifier = (
-        "https://altinn-model-publisher.digdir.no/models/4985-5704/"
-    )
+    os.environ[
+        baseurl_key
+    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
 
     _skolemization = (
         "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/X"
@@ -1507,10 +1514,23 @@ def test_has_skolemization_morfologi_incorrect_counter() -> None:
 def test_has_skolemization_morfologi_incorrect_class() -> None:
     """Tests skolemization morfologi."""
     informationmodel = InformationModel()
-    informationmodel.identifier = (
-        "https://altinn-model-publisher.digdir.no/models/4985-5704/"
-    )
+    os.environ[
+        baseurl_key
+    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
 
     _skolemization = "https://altinn-model-publisher.digdir.no/models/4985-5704/Foo/1"
 
     assert not informationmodel.has_skolemization_morfologi(_skolemization)
+
+
+def test_get_baseurl() -> None:
+    """Tests the retrieving of the baseurl for skolemization."""
+    if baseurl_key in os.environ.keys():
+        del os.environ[baseurl_key]
+
+    assert InformationModel.get_baseurl() == baseurl_default_value
+
+    os.environ[baseurl_key] = baseurl_default_value
+
+    assert baseurl_key in os.environ
+    assert os.environ[baseurl_key] == baseurl_default_value

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -1,5 +1,4 @@
 """Test cases for the informationmodel module."""
-import os
 from typing import List, Union
 
 from concepttordf import Concept, Contact
@@ -10,8 +9,6 @@ from rdflib import Graph, Namespace
 from modelldcatnotordf.document import FoafDocument
 from modelldcatnotordf.licensedocument import LicenseDocument
 from modelldcatnotordf.modelldcatno import (
-    baseurl_default_value,
-    baseurl_key,
     InformationModel,
     ModelElement,
     ObjectType,
@@ -1444,93 +1441,3 @@ def test_to_graph_should_return_has_format_as_uri() -> None:
     g2 = Graph().parse(data=src, format="turtle")
 
     assert_isomorphic(g1, g2)
-
-
-def test_add_skolemization() -> None:
-    """Tests skolemization."""
-    informationmodel = InformationModel()
-    os.environ[
-        baseurl_key
-    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
-
-    modelelement = ObjectType()
-
-    skolemization1 = (
-        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/1"
-    )
-
-    skolemization2 = (
-        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/2"
-    )
-
-    assert not informationmodel.is_exact_skolemization(skolemization1)
-    assert skolemization1 == informationmodel.add_skolemization(modelelement)
-    assert informationmodel.is_exact_skolemization(skolemization1)
-    assert not informationmodel.is_exact_skolemization(skolemization2)
-    assert skolemization2 == informationmodel.add_skolemization(modelelement)
-    assert informationmodel.is_exact_skolemization(skolemization2)
-
-
-def test_has_skolemization_morfologi_success() -> None:
-    """Tests skolemization morfologi."""
-    informationmodel = InformationModel()
-    os.environ[
-        baseurl_key
-    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
-
-    _skolemization = (
-        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/2"
-    )
-
-    assert informationmodel.has_skolemization_morfologi(_skolemization)
-
-
-def test_has_skolemization_morfologi_incorrect_identifier() -> None:
-    """Tests skolemization morfologi."""
-    informationmodel = InformationModel()
-    os.environ[
-        baseurl_key
-    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
-
-    _skolemization = "https://someWrongIdentifier/ObjectType/2"
-
-    assert not informationmodel.has_skolemization_morfologi(_skolemization)
-
-
-def test_has_skolemization_morfologi_incorrect_counter() -> None:
-    """Tests skolemization morfologi."""
-    informationmodel = InformationModel()
-    os.environ[
-        baseurl_key
-    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
-
-    _skolemization = (
-        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/X"
-    )
-
-    assert not informationmodel.has_skolemization_morfologi(_skolemization)
-
-
-def test_has_skolemization_morfologi_incorrect_class() -> None:
-    """Tests skolemization morfologi."""
-    informationmodel = InformationModel()
-    os.environ[
-        baseurl_key
-    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
-
-    _skolemization = "https://altinn-model-publisher.digdir.no/models/4985-5704/Foo/1"
-
-    assert not informationmodel.has_skolemization_morfologi(_skolemization)
-
-
-def test_get_baseurl() -> None:
-    """Tests the retrieving of the baseurl for skolemization."""
-    if baseurl_key in os.environ.keys():
-        del os.environ[baseurl_key]
-
-    assert InformationModel.get_baseurl() == baseurl_default_value
-
-    os.environ[baseurl_key] = baseurl_default_value
-
-    assert baseurl_key in os.environ
-    assert os.environ[baseurl_key] == baseurl_default_value

--- a/tests/test_objecttype.py
+++ b/tests/test_objecttype.py
@@ -2,10 +2,11 @@
 
 from concepttordf import Concept
 import pytest
+from pytest_mock import MockFixture
 from rdflib import Graph
 
 from modelldcatnotordf.modelldcatno import ObjectType
-from tests.testutils import assert_isomorphic
+from tests.testutils import assert_isomorphic, skolemization
 
 """
 A test class for testing the class ObjectType.
@@ -46,10 +47,15 @@ def test_to_graph_should_return_title_and_identifier() -> None:
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_title_and_no_identifier() -> None:
+def test_to_graph_should_return_title_and_skolemization(mocker: MockFixture) -> None:
     """It returns a title graph isomorphic to spec."""
     objectype = ObjectType()
     objectype.title = {"nb": "Tittel 1", "en": "Title 1"}
+
+    mocker.patch(
+        "modelldcatnotordf.skolemizer.Skolemizer.add_skolemization",
+        return_value=skolemization,
+    )
 
     src = """
         @prefix dct: <http://purl.org/dc/terms/> .
@@ -58,9 +64,10 @@ def test_to_graph_should_return_title_and_no_identifier() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        [ a modelldcatno:ObjectType ;
+        <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+        a modelldcatno:ObjectType ;
             dct:title   "Title 1"@en, "Tittel 1"@nb ;
-        ]
+
         .
         """
     g1 = Graph().parse(data=objectype.to_rdf(), format="turtle")

--- a/tests/test_skolemizer.py
+++ b/tests/test_skolemizer.py
@@ -1,0 +1,117 @@
+"""Test cases for the skolemizer module."""
+import os
+
+from modelldcatnotordf.modelldcatno import ObjectType
+from modelldcatnotordf.modelldcatno import Skolemizer
+
+"""
+A test class for testing the class InformationModel.
+
+"""
+
+
+def test_add_skolemization() -> None:
+    """Tests skolemization."""
+    os.environ[
+        Skolemizer.baseurl_key
+    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
+
+    modelelement = ObjectType()
+
+    _classtype = modelelement.__class__.__name__
+
+    skolemization1 = (
+        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/1"
+    )
+
+    skolemization2 = (
+        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/2"
+    )
+
+    assert not Skolemizer.is_exact_skolemization(skolemization1)
+    assert skolemization1 == Skolemizer.add_skolemization(_classtype)
+    assert Skolemizer.is_exact_skolemization(skolemization1)
+    assert not Skolemizer.is_exact_skolemization(skolemization2)
+    assert skolemization2 == Skolemizer.add_skolemization(_classtype)
+    assert Skolemizer.is_exact_skolemization(skolemization2)
+
+
+def test_has_skolemization_morfologi_success() -> None:
+    """Tests skolemization morfologi."""
+    os.environ[
+        Skolemizer.baseurl_key
+    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
+
+    _skolemization = (
+        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/2"
+    )
+
+    assert Skolemizer.has_skolemization_morfologi(_skolemization)
+
+
+def test_has_skolemization_morfologi_incorrect_identifier() -> None:
+    """Tests skolemization morfologi."""
+    os.environ[
+        Skolemizer.baseurl_key
+    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
+
+    _skolemization = "https://someWrongIdentifier/ObjectType/2"
+
+    assert not Skolemizer.has_skolemization_morfologi(_skolemization)
+
+
+def test_has_skolemization_morfologi_incorrect_counter() -> None:
+    """Tests skolemization morfologi."""
+    os.environ[
+        Skolemizer.baseurl_key
+    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
+
+    _skolemization = (
+        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/X"
+    )
+
+    assert not Skolemizer.has_skolemization_morfologi(_skolemization)
+
+
+def test_has_skolemization_morfologi_incorrect_class() -> None:
+    """Tests skolemization morfologi."""
+    os.environ[
+        Skolemizer.baseurl_key
+    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
+
+    _skolemization = "https://altinn-model-publisher.digdir.no/models/4985-5704/Foo/1"
+
+    assert not Skolemizer.has_skolemization_morfologi(_skolemization)
+
+
+def test_get_baseurl() -> None:
+    """Tests the retrieving of the baseurl for skolemization."""
+    if Skolemizer.baseurl_key in os.environ.keys():
+        del os.environ[Skolemizer.baseurl_key]
+
+    assert Skolemizer.get_baseurl() == Skolemizer.baseurl_default_value
+
+    os.environ[Skolemizer.baseurl_key] = Skolemizer.baseurl_default_value
+
+    assert Skolemizer.baseurl_key in os.environ
+    assert os.environ[Skolemizer.baseurl_key] == Skolemizer.baseurl_default_value
+
+
+def test_get_baseurl_not_valid_url() -> None:
+    """Tests the retrieving of the baseurl for skolemization."""
+    if Skolemizer.baseurl_key in os.environ.keys():
+        del os.environ[Skolemizer.baseurl_key]
+
+    os.environ[Skolemizer.baseurl_key] = Skolemizer.baseurl_default_value + "<>"
+
+    assert Skolemizer.get_baseurl() == Skolemizer.baseurl_default_value
+
+
+def test_get_baseurl_missing_slash_at_end() -> None:
+    """Tests the retrieving of the baseurl for skolemization."""
+    if Skolemizer.baseurl_key in os.environ.keys():
+        del os.environ[Skolemizer.baseurl_key]
+
+    os.environ[Skolemizer.baseurl_key] = Skolemizer.baseurl_default_value[:-1]
+
+    assert Skolemizer.get_baseurl() == Skolemizer.baseurl_default_value

--- a/tests/test_skolemizer.py
+++ b/tests/test_skolemizer.py
@@ -1,7 +1,6 @@
 """Test cases for the skolemizer module."""
 import os
 
-from modelldcatnotordf.modelldcatno import ObjectType
 from modelldcatnotordf.modelldcatno import Skolemizer
 
 """
@@ -12,76 +11,20 @@ A test class for testing the class InformationModel.
 
 def test_add_skolemization() -> None:
     """Tests skolemization."""
-    os.environ[
-        Skolemizer.baseurl_key
-    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
+    skolemization1 = Skolemizer.add_skolemization()
+    skolemization2 = Skolemizer.add_skolemization()
 
-    modelelement = ObjectType()
-
-    _classtype = modelelement.__class__.__name__
-
-    skolemization1 = (
-        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/1"
+    assert skolemization1.startswith(
+        Skolemizer.baseurl_default_value + ".well-known/skolem/"
     )
-
-    skolemization2 = (
-        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/2"
-    )
-
-    assert not Skolemizer.is_exact_skolemization(skolemization1)
-    assert skolemization1 == Skolemizer.add_skolemization(_classtype)
+    assert Skolemizer.has_skolemization_morfologi(skolemization1)
     assert Skolemizer.is_exact_skolemization(skolemization1)
-    assert not Skolemizer.is_exact_skolemization(skolemization2)
-    assert skolemization2 == Skolemizer.add_skolemization(_classtype)
+
+    assert skolemization2.startswith(
+        Skolemizer.baseurl_default_value + ".well-known/skolem/"
+    )
+    assert Skolemizer.has_skolemization_morfologi(skolemization2)
     assert Skolemizer.is_exact_skolemization(skolemization2)
-
-
-def test_has_skolemization_morfologi_success() -> None:
-    """Tests skolemization morfologi."""
-    os.environ[
-        Skolemizer.baseurl_key
-    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
-
-    _skolemization = (
-        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/2"
-    )
-
-    assert Skolemizer.has_skolemization_morfologi(_skolemization)
-
-
-def test_has_skolemization_morfologi_incorrect_identifier() -> None:
-    """Tests skolemization morfologi."""
-    os.environ[
-        Skolemizer.baseurl_key
-    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
-
-    _skolemization = "https://someWrongIdentifier/ObjectType/2"
-
-    assert not Skolemizer.has_skolemization_morfologi(_skolemization)
-
-
-def test_has_skolemization_morfologi_incorrect_counter() -> None:
-    """Tests skolemization morfologi."""
-    os.environ[
-        Skolemizer.baseurl_key
-    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
-
-    _skolemization = (
-        "https://altinn-model-publisher.digdir.no/models/4985-5704/ObjectType/X"
-    )
-
-    assert not Skolemizer.has_skolemization_morfologi(_skolemization)
-
-
-def test_has_skolemization_morfologi_incorrect_class() -> None:
-    """Tests skolemization morfologi."""
-    os.environ[
-        Skolemizer.baseurl_key
-    ] = "https://altinn-model-publisher.digdir.no/models/4985-5704/"
-
-    _skolemization = "https://altinn-model-publisher.digdir.no/models/4985-5704/Foo/1"
-
-    assert not Skolemizer.has_skolemization_morfologi(_skolemization)
 
 
 def test_get_baseurl() -> None:
@@ -115,3 +58,15 @@ def test_get_baseurl_missing_slash_at_end() -> None:
     os.environ[Skolemizer.baseurl_key] = Skolemizer.baseurl_default_value[:-1]
 
     assert Skolemizer.get_baseurl() == Skolemizer.baseurl_default_value
+
+
+def test_has_skolemization_morfologi_invalid_url() -> None:
+    """Tests skolemization for invalid url."""
+    skolemization = Skolemizer.add_skolemization()
+
+    assert skolemization.startswith(
+        Skolemizer.baseurl_default_value + ".well-known/skolem/"
+    )
+
+    assert Skolemizer.has_skolemization_morfologi(skolemization)
+    assert not Skolemizer.has_skolemization_morfologi(skolemization + "<")

--- a/tests/test_skolemizer.py
+++ b/tests/test_skolemizer.py
@@ -1,7 +1,7 @@
 """Test cases for the skolemizer module."""
 import os
 
-from modelldcatnotordf.modelldcatno import Skolemizer
+from modelldcatnotordf.skolemizer import Skolemizer
 
 """
 A test class for testing the class InformationModel.

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,7 +1,42 @@
 """Utils for displaying debug information."""
+from typing import List, Union
 
+from datacatalogtordf import URI
 from rdflib import Graph
 from rdflib.compare import graph_diff, isomorphic
+
+from modelldcatnotordf.skolemizer import Skolemizer
+
+uuid = "284db4d2-80c2-11eb-82c3-83e80baa2f94"
+skolemization = Skolemizer.get_baseurl() + ".well-known/skolem/" + uuid
+
+uuid2 = "21043186-80ce-11eb-9829-cf7c8fc855ce"
+skolemization2 = Skolemizer.get_baseurl() + ".well-known/skolem/" + uuid2
+
+uuid3 = "279b7540-80ce-11eb-ba1a-7fa81b1658fe"
+skolemization3 = Skolemizer.get_baseurl() + ".well-known/skolem/" + uuid3
+
+
+class SkolemUtils:
+    """Testutils for mocking more than one skolemization."""
+
+    skolemization_counter: int
+    skolemizations: List
+
+    def __init__(self) -> None:
+        """Constructor."""
+        self.skolemization_counter = 0
+        self.skolemizations = [skolemization, skolemization2, skolemization3]
+
+    def get_skolemization(self) -> Union[URI, None]:
+        """Pops a skolemization from a stack of max 3 test skolemizations."""
+        if self.skolemization_counter == 3:
+            return None
+
+        _skolemization = self.skolemizations[self.skolemization_counter]
+        self.skolemization_counter = self.skolemization_counter + 1
+
+        return _skolemization
 
 
 def assert_isomorphic(g1: Graph, g2: Graph) -> None:


### PR DESCRIPTION
Her kommer det en liten draft på det som er gjort hittil på forsøk på skolemisering.

Motivasjonen for å gjøre dette er å erstatte behovet for blanke noder ved å legge til en skolemisert form av identifier, slik at vi kan oppnå støtte for mer enn to generasjoner av nøstede noder i grafen.

Tanken er at alle steder i `to_graph`-metodene der vi i dag har f.eks

```
                    _modelelement = (
                        URIRef(modelelement.identifier)
                        if getattr(modelelement, "identifier", None)
                        else BNode()
```

så skal det stå noe slikt som 

```
    if getattr(modelelement, "identifier", None):
                        _modelelement = URIRef(modelelement.identifier)
                    else:
                        _modelelement = URIRef(Skolemizer.add_skolemization(ModelElement))
```
Skolemizeren vil da opprette og returnere en skolemisering og legge dette til et bokholderi. Metoden `add_skolemization(classtype: Any)` gjør dette og metoden `is_exact_skolemization(skolemization: URI)` tester om en gitt skolemisert URI er lagt til i bokholderiet.

Ønsket er at alt dette skal skje bak kulissene og at de som bruker parseren ikke skal trenge å forholde seg til skolemiseringen.

Hovedutfordringen slik jeg ser det nå er at skolemizer'en må på en måte være global innenfor modelldcatno, samtidig som den er knyttet til det aktuelle informasjonsmodell-objektet siden den bruker identifieren til informasjonsmodellen som grunnlag for skolemiseringen.

De underliggende nodene i modelldcatno har ikke noe forhold til det primære informasjonsmodellobjektet men samtidig må de ha tilgang til skolemizeren. Så da må skolemizeren på en måte være global eller static. Akkurat nå ligger all logikken for øyeblikket under InformationModel, men jeg tenker å ta det ut i en egen klasse dersom dette gjør det mulig å gi alle klassene i modellen global tilgang til den. Men for at den skal kunne være global/static så må den også så vidt jeg forstår være tilstandsløs. Det kan den være med unntak av at den trenger identifieren til informasjonsmodellen. 

Så spørsmålet er egentlig om den kan være global og uten å være helt tilstandsløs slik at alle klassene i modelldcatno får tilgang til den uten å ha tilgang til det primære informasjonsmodellobjektet. Eller om dette skal løses på en helt annen måte. 

Et annet alternativ kan være å ikke knytte skolemiseringen til en informasjonsmodell, men heller bruke en form for UUID i stedet for informasjonsmodellen sin identifier. Da vil man slippe å ha skolemiser'en knyttet til informasjonsmodellen, men den er fortsatt ikke helt tilstandsløs fordi den er avhengig av en gitt UUID. Men da kunne den være et globalt tilgjengelig objekt innenfor modelldcatno. Da ville alle klassene i ha tilgang til skolemiseren, informasjonsmodellen også, uten at skolemiseren var avhengig av noen av klassene i modelldcatno.

I tillegg har jeg laget en metode, `has_skolemization_morfologi(skolemization: URI)`, for å gjenkjenne skolemisert form uten at de ligger i bokholderiet til skolemiseringen. Dette for at det skal kunne gjenkjennes som skolemisert selv om den eksakte skolemiseringen ikke er i bokholderiet run-time. Det er ikke sikkert at vi trenger denne metoden likevel..

Testene som er satt opp er forsøk på å synliggjøre litt slik det som er laget hittil er tenkt å fungere, f.eks slik skolemiseringslogikken er tenkt å være..


