### PR TITLE
Fix/skolemisering 1

### DIFF
--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -2482,9 +2482,9 @@ class DataType(ModelElement):
         Returns:
             the object type graph
         """
-        _self = (
-            URIRef(self.identifier) if getattr(self, "identifier", None) else BNode()
-        )
+        if not getattr(self, "identifier", None):
+            self.identifier = Skolemizer.add_skolemization()
+        _self = URIRef(self.identifier)
 
         super(DataType, self)._to_graph(MODELLDCATNO.DataType, _self)
 

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -942,20 +942,16 @@ class ModelElement(ABC):
             for has_property in self._has_property:
 
                 if isinstance(has_property, ModelProperty):
-                    _has_property = (
-                        URIRef(has_property.identifier)
-                        if getattr(has_property, "identifier", None)
-                        else BNode()
-                    )
+
+                    if not getattr(has_property, "identifier", None):
+                        has_property.identifier = Skolemizer.add_skolemization()
+
+                    _has_property = URIRef(has_property.identifier)
 
                     for _s, p, o in has_property._to_graph().triples(
                         (None, None, None)
                     ):
-                        self._g.add(
-                            (_has_property, p, o)
-                            if isinstance(_has_property, BNode)
-                            else (_s, p, o)
-                        )
+                        self._g.add((_s, p, o))
 
                 elif isinstance(has_property, str):
                     _has_property = URIRef(has_property)

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -2068,9 +2068,9 @@ class Attribute(ModelProperty):
         Returns:
             the role graph
         """
-        _self = (
-            URIRef(self.identifier) if getattr(self, "identifier", None) else BNode()
-        )
+        if not getattr(self, "identifier", None):
+            self.identifier = Skolemizer.add_skolemization()
+        _self = URIRef(self.identifier)
 
         super(Attribute, self)._to_graph(MODELLDCATNO.Attribute, _self)
 

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -2134,20 +2134,17 @@ class Attribute(ModelProperty):
         if getattr(self, "has_data_type", None):
 
             if isinstance(self.has_data_type, DataType):
-                _has_data_type = (
-                    URIRef(self._has_data_type.identifier)
-                    if getattr(self._has_data_type, "identifier", None)
-                    else BNode()
-                )
+
+                if not getattr(self.has_data_type, "identifier", None):
+                    self.has_data_type.identifier = Skolemizer.add_skolemization()
+
+                _has_data_type = URIRef(self._has_data_type.identifier)
 
                 for _s, p, o in self._has_data_type._to_graph().triples(
                     (None, None, None)
                 ):
-                    self._g.add(
-                        (_has_data_type, p, o)
-                        if isinstance(_has_data_type, BNode)
-                        else (_s, p, o)
-                    )
+                    self._g.add((_s, p, o))
+
             elif isinstance(self.has_data_type, str):
                 _has_data_type = URIRef(self.has_data_type)
 

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -355,7 +355,9 @@ def test_to_graph_should_return_has_data_type_both_identifiers() -> None:
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_has_data_type_bnode_attribute_id() -> None:
+def test_to_graph_should_return_has_data_type_bnode_attribute_id(
+    mocker: MockFixture,
+) -> None:
     """It returns a has_data_type graph isomorphic to spec."""
     attribute = Attribute()
     attribute.identifier = "http://example.com/attributes/1"
@@ -363,17 +365,26 @@ def test_to_graph_should_return_has_data_type_bnode_attribute_id() -> None:
     datatype = DataType()
     attribute.has_data_type = datatype
 
+    mocker.patch(
+        "modelldcatnotordf.skolemizer.Skolemizer.add_skolemization",
+        return_value=skolemization,
+    )
+
     src = """
-        @prefix dct: <http://purl.org/dc/terms/> .
-        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-        @prefix dcat: <http://www.w3.org/ns/dcat#> .
-        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        <http://example.com/attributes/1> a modelldcatno:Attribute ;
-            modelldcatno:hasDataType [ a modelldcatno:DataType ] .
+    <http://example.com/attributes/1> a modelldcatno:Attribute ;
+        modelldcatno:hasDataType
+    <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94> .
 
-        """
+    <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+        a modelldcatno:DataType  .
+
+    """
     g1 = Graph().parse(data=attribute.to_rdf(), format="turtle")
     g2 = Graph().parse(data=src, format="turtle")
 
@@ -433,15 +444,19 @@ def test_to_graph_should_return_has_data_type_both_skolemized(
     )
 
     src = """
-        @prefix dct: <http://purl.org/dc/terms/> .
-        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-        @prefix dcat: <http://www.w3.org/ns/dcat#> .
-        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
-         a modelldcatno:Attribute ;
-            modelldcatno:hasDataType [ a modelldcatno:DataType ]
+    <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+        a modelldcatno:Attribute ; modelldcatno:hasDataType
+        <http://wwww.digdir.no/.well-known/skolem/21043186-80ce-11eb-9829-cf7c8fc855ce>
+    .
+
+    <http://wwww.digdir.no/.well-known/skolem/21043186-80ce-11eb-9829-cf7c8fc855ce>
+        a modelldcatno:DataType
          .
         """
     g1 = Graph().parse(data=attribute.to_rdf(), format="turtle")

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -1,5 +1,6 @@
 """Test cases for the attribute module."""
 import pytest
+from pytest_mock import MockFixture
 from rdflib import Graph
 
 from modelldcatnotordf.modelldcatno import (
@@ -9,7 +10,8 @@ from modelldcatnotordf.modelldcatno import (
     ObjectType,
     SimpleType,
 )
-from tests.testutils import assert_isomorphic
+from tests import testutils
+from tests.testutils import assert_isomorphic, skolemization
 
 """
 A test class for testing the class Attribute.
@@ -25,9 +27,14 @@ def test_instantiate_attribute() -> None:
         pytest.fail("Unexpected Exception ..")
 
 
-def test_to_graph_should_return_blank_node() -> None:
+def test_to_graph_should_return_skolemization(mocker: MockFixture) -> None:
     """It returns a attribute graph as blank node isomorphic to spec."""
     attribute = Attribute()
+
+    mocker.patch(
+        "modelldcatnotordf.skolemizer.Skolemizer.add_skolemization",
+        return_value=skolemization,
+    )
 
     src = """
         @prefix dct: <http://purl.org/dc/terms/> .
@@ -36,7 +43,8 @@ def test_to_graph_should_return_blank_node() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        [ a modelldcatno:Attribute ] .
+        <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+         a modelldcatno:Attribute  .
 
         """
     g1 = Graph().parse(data=attribute.to_rdf(), format="turtle")
@@ -120,13 +128,20 @@ def test_to_graph_should_return_contains_object_type_bnode_attribute_id() -> Non
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_contains_object_type_blank_node_objecttype() -> None:
+def test_to_graph_should_return_contains_object_type_objecttype_id(
+    mocker: MockFixture,
+) -> None:
     """It returns a contains_object_type graph isomorphic to spec."""
     attribute = Attribute()
 
     objecttype = ObjectType()
     objecttype.identifier = "http://example.com/objecttypes/1"
     attribute.contains_object_type = objecttype
+
+    mocker.patch(
+        "modelldcatnotordf.skolemizer.Skolemizer.add_skolemization",
+        return_value=skolemization,
+    )
 
     src = """
         @prefix dct: <http://purl.org/dc/terms/> .
@@ -135,9 +150,10 @@ def test_to_graph_should_return_contains_object_type_blank_node_objecttype() -> 
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        [ a modelldcatno:Attribute ;
+        <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+         a modelldcatno:Attribute ;
             modelldcatno:containsObjectType <http://example.com/objecttypes/1>
-        ] .
+         .
 
         <http://example.com/objecttypes/1> a modelldcatno:ObjectType .
 
@@ -148,12 +164,21 @@ def test_to_graph_should_return_contains_object_type_blank_node_objecttype() -> 
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_contains_object_type_blank_nodes() -> None:
+def test_to_graph_should_return_contains_object_type_both_skolemizations(
+    mocker: MockFixture,
+) -> None:
     """It returns a contains_object_type graph isomorphic to spec."""
     attribute = Attribute()
 
     objecttype = ObjectType()
     attribute.contains_object_type = objecttype
+
+    skolemutils = testutils.SkolemUtils()
+
+    mocker.patch(
+        "modelldcatnotordf.skolemizer.Skolemizer.add_skolemization",
+        side_effect=skolemutils.get_skolemization,
+    )
 
     src = """
         @prefix dct: <http://purl.org/dc/terms/> .
@@ -162,9 +187,12 @@ def test_to_graph_should_return_contains_object_type_blank_nodes() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        [ a modelldcatno:Attribute ;
-            modelldcatno:containsObjectType [ a modelldcatno:ObjectType ]
-        ] .
+        <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+         a modelldcatno:Attribute ;
+            modelldcatno:containsObjectType
+                [ a modelldcatno:ObjectType ]
+     .
+
         """
     g1 = Graph().parse(data=attribute.to_rdf(), format="turtle")
     g2 = Graph().parse(data=src, format="turtle")
@@ -226,13 +254,22 @@ def test_to_graph_should_return_has_simple_type_bnode_attribute_id() -> None:
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_has_simple_type_blank_node_simpletype() -> None:
+def test_to_graph_should_return_has_simple_type_skolemization_simpletype(
+    mocker: MockFixture,
+) -> None:
     """It returns a has_simple_type graph isomorphic to spec."""
     attribute = Attribute()
 
     simpletype = SimpleType()
     simpletype.identifier = "http://example.com/simpletypes/1"
     attribute.has_simple_type = simpletype
+
+    skolemutils = testutils.SkolemUtils()
+
+    mocker.patch(
+        "modelldcatnotordf.skolemizer.Skolemizer.add_skolemization",
+        side_effect=skolemutils.get_skolemization,
+    )
 
     src = """
         @prefix dct: <http://purl.org/dc/terms/> .
@@ -241,9 +278,10 @@ def test_to_graph_should_return_has_simple_type_blank_node_simpletype() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        [ a modelldcatno:Attribute ;
+        <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+         a modelldcatno:Attribute ;
             modelldcatno:hasSimpleType <http://example.com/simpletypes/1>
-        ] .
+         .
 
         <http://example.com/simpletypes/1> a modelldcatno:SimpleType .
 
@@ -254,12 +292,21 @@ def test_to_graph_should_return_has_simple_type_blank_node_simpletype() -> None:
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_has_simple_type_blank_nodes() -> None:
+def test_to_graph_should_return_has_simple_type_both_skolemized(
+    mocker: MockFixture,
+) -> None:
     """It returns a has_simple_type graph isomorphic to spec."""
     attribute = Attribute()
 
     simpletype = SimpleType()
     attribute.has_simple_type = simpletype
+
+    skolemutils = testutils.SkolemUtils()
+
+    mocker.patch(
+        "modelldcatnotordf.skolemizer.Skolemizer.add_skolemization",
+        side_effect=skolemutils.get_skolemization,
+    )
 
     src = """
         @prefix dct: <http://purl.org/dc/terms/> .
@@ -268,9 +315,10 @@ def test_to_graph_should_return_has_simple_type_blank_nodes() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        [ a modelldcatno:Attribute ;
+        <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+         a modelldcatno:Attribute ;
             modelldcatno:hasSimpleType [ a modelldcatno:SimpleType ]
-        ] .
+         .
         """
     g1 = Graph().parse(data=attribute.to_rdf(), format="turtle")
     g2 = Graph().parse(data=src, format="turtle")
@@ -332,13 +380,20 @@ def test_to_graph_should_return_has_data_type_bnode_attribute_id() -> None:
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_has_data_type_blank_node_datatype() -> None:
+def test_to_graph_should_return_has_data_type_skolemization_datatype(
+    mocker: MockFixture,
+) -> None:
     """It returns a has_data_type graph isomorphic to spec."""
     attribute = Attribute()
 
     datatype = DataType()
     datatype.identifier = "http://example.com/datatypes/1"
     attribute.has_data_type = datatype
+
+    mocker.patch(
+        "modelldcatnotordf.skolemizer.Skolemizer.add_skolemization",
+        return_value=skolemization,
+    )
 
     src = """
         @prefix dct: <http://purl.org/dc/terms/> .
@@ -347,9 +402,10 @@ def test_to_graph_should_return_has_data_type_blank_node_datatype() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        [ a modelldcatno:Attribute ;
+        <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+         a modelldcatno:Attribute ;
             modelldcatno:hasDataType <http://example.com/datatypes/1>
-        ] .
+         .
 
         <http://example.com/datatypes/1> a modelldcatno:DataType .
 
@@ -360,12 +416,21 @@ def test_to_graph_should_return_has_data_type_blank_node_datatype() -> None:
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_has_data_type_blank_nodes() -> None:
+def test_to_graph_should_return_has_data_type_both_skolemized(
+    mocker: MockFixture,
+) -> None:
     """It returns a has_data_type graph isomorphic to spec."""
     attribute = Attribute()
 
     datatype = DataType()
     attribute.has_data_type = datatype
+
+    skolemutils = testutils.SkolemUtils()
+
+    mocker.patch(
+        "modelldcatnotordf.skolemizer.Skolemizer.add_skolemization",
+        side_effect=skolemutils.get_skolemization,
+    )
 
     src = """
         @prefix dct: <http://purl.org/dc/terms/> .
@@ -374,9 +439,10 @@ def test_to_graph_should_return_has_data_type_blank_nodes() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        [ a modelldcatno:Attribute ;
+        <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+         a modelldcatno:Attribute ;
             modelldcatno:hasDataType [ a modelldcatno:DataType ]
-        ] .
+         .
         """
     g1 = Graph().parse(data=attribute.to_rdf(), format="turtle")
     g2 = Graph().parse(data=src, format="turtle")
@@ -438,8 +504,15 @@ def test_to_graph_should_return_has_value_from_bnode_attribute_id() -> None:
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_has_value_from_blank_node_codelist() -> None:
+def test_to_graph_should_return_has_value_from_skolemization_codelist(
+    mocker: MockFixture,
+) -> None:
     """It returns a has_value_from graph isomorphic to spec."""
+    mocker.patch(
+        "modelldcatnotordf.skolemizer.Skolemizer.add_skolemization",
+        return_value=skolemization,
+    )
+
     attribute = Attribute()
 
     codelist = CodeList()
@@ -453,9 +526,10 @@ def test_to_graph_should_return_has_value_from_blank_node_codelist() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        [ a modelldcatno:Attribute ;
+        <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+         a modelldcatno:Attribute ;
             modelldcatno:hasValueFrom <http://example.com/codelists/1>
-        ] .
+         .
 
         <http://example.com/codelists/1> a modelldcatno:CodeList .
 
@@ -466,12 +540,21 @@ def test_to_graph_should_return_has_value_from_blank_node_codelist() -> None:
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_has_value_from_blank_nodes() -> None:
+def test_to_graph_should_return_has_value_from_both_skolemized(
+    mocker: MockFixture,
+) -> None:
     """It returns a has_value_from graph isomorphic to spec."""
     attribute = Attribute()
 
     codelist = CodeList()
     attribute.has_value_from = codelist
+
+    skolemutils = testutils.SkolemUtils()
+
+    mocker.patch(
+        "modelldcatnotordf.skolemizer.Skolemizer.add_skolemization",
+        side_effect=skolemutils.get_skolemization,
+    )
 
     src = """
         @prefix dct: <http://purl.org/dc/terms/> .
@@ -480,9 +563,10 @@ def test_to_graph_should_return_has_value_from_blank_nodes() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        [ a modelldcatno:Attribute ;
+        <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+         a modelldcatno:Attribute ;
             modelldcatno:hasValueFrom [ a modelldcatno:CodeList ]
-        ] .
+         .
         """
     g1 = Graph().parse(data=attribute.to_rdf(), format="turtle")
     g2 = Graph().parse(data=src, format="turtle")

--- a/tests/test_datatype.py
+++ b/tests/test_datatype.py
@@ -56,7 +56,6 @@ def test_to_graph_should_return_title_and_skolemization(mocker: MockFixture) -> 
         "modelldcatnotordf.skolemizer.Skolemizer.add_skolemization",
         return_value=skolemization,
     )
-
     src = """
         @prefix dct: <http://purl.org/dc/terms/> .
         @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/tests/test_datatype.py
+++ b/tests/test_datatype.py
@@ -2,10 +2,11 @@
 
 from concepttordf import Concept
 import pytest
+from pytest_mock import MockFixture
 from rdflib import Graph
 
 from modelldcatnotordf.modelldcatno import DataType
-from tests.testutils import assert_isomorphic
+from tests.testutils import assert_isomorphic, skolemization
 
 """
 A test class for testing the class DataType.
@@ -46,10 +47,15 @@ def test_to_graph_should_return_title_and_identifier() -> None:
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_title_and_no_identifier() -> None:
+def test_to_graph_should_return_title_and_skolemization(mocker: MockFixture) -> None:
     """It returns a title graph isomorphic to spec."""
     datatype = DataType()
     datatype.title = {"nb": "Tittel 1", "en": "Title 1"}
+
+    mocker.patch(
+        "modelldcatnotordf.skolemizer.Skolemizer.add_skolemization",
+        return_value=skolemization,
+    )
 
     src = """
         @prefix dct: <http://purl.org/dc/terms/> .
@@ -58,9 +64,9 @@ def test_to_graph_should_return_title_and_no_identifier() -> None:
         @prefix dcat: <http://www.w3.org/ns/dcat#> .
         @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        [ a modelldcatno:DataType ;
+        <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+         a modelldcatno:DataType ;
             dct:title   "Title 1"@en, "Tittel 1"@nb ;
-        ]
         .
         """
     g1 = Graph().parse(data=datatype.to_rdf(), format="turtle")

--- a/tests/test_modelelement.py
+++ b/tests/test_modelelement.py
@@ -8,6 +8,7 @@ from pytest_mock import MockFixture
 from rdflib import Graph
 
 from modelldcatnotordf.modelldcatno import ModelElement, ModelProperty, ObjectType, Role
+from tests import testutils
 from tests.testutils import assert_isomorphic, skolemization
 
 """
@@ -159,7 +160,9 @@ def test_to_graph_should_return_has_property_both_identifiers() -> None:
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_has_property_bnode_modelelement_id() -> None:
+def test_to_graph_should_return_has_property_bnode_modelelement_id(
+    mocker: MockFixture,
+) -> None:
     """It returns a has_property graph isomorphic to spec."""
     modelelement = ObjectType()
     modelelement.identifier = "http://example.com/modelelements/1"
@@ -167,17 +170,27 @@ def test_to_graph_should_return_has_property_bnode_modelelement_id() -> None:
     modelproperty = Role()
     modelelement.has_property.append(modelproperty)
 
+    mocker.patch(
+        "modelldcatnotordf.skolemizer.Skolemizer.add_skolemization",
+        return_value=skolemization,
+    )
+
     src = """
-        @prefix dct: <http://purl.org/dc/terms/> .
-        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-        @prefix dcat: <http://www.w3.org/ns/dcat#> .
-        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        <http://example.com/modelelements/1> a modelldcatno:ObjectType ;
-            modelldcatno:hasProperty [ a modelldcatno:Role ] .
+    <http://example.com/modelelements/1> a modelldcatno:ObjectType ;
+        modelldcatno:hasProperty
+        <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+        .
 
-        """
+    <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+        a modelldcatno:Role  .
+    """
+
     g1 = Graph().parse(data=modelelement.to_rdf(), format="turtle")
     g2 = Graph().parse(data=src, format="turtle")
 
@@ -229,23 +242,30 @@ def test_to_graph_should_return_has_property_both_skolemizations(
     modelproperty = Role()
     modelelement.has_property.append(modelproperty)
 
+    skolemutils = testutils.SkolemUtils()
+
     mocker.patch(
         "modelldcatnotordf.skolemizer.Skolemizer.add_skolemization",
-        return_value=skolemization,
+        side_effect=skolemutils.get_skolemization,
     )
 
     src = """
-        @prefix dct: <http://purl.org/dc/terms/> .
-        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-        @prefix dcat: <http://www.w3.org/ns/dcat#> .
-        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
-        <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
-         a modelldcatno:ObjectType ;
-            modelldcatno:hasProperty [ a modelldcatno:Role ]
-         .
-        """
+    <http://wwww.digdir.no/.well-known/skolem/284db4d2-80c2-11eb-82c3-83e80baa2f94>
+    a modelldcatno:ObjectType ; modelldcatno:hasProperty
+    <http://wwww.digdir.no/.well-known/skolem/21043186-80ce-11eb-9829-cf7c8fc855ce>
+    .
+
+    <http://wwww.digdir.no/.well-known/skolem/21043186-80ce-11eb-9829-cf7c8fc855ce>
+        a modelldcatno:Role
+    .
+    """
+
     g1 = Graph().parse(data=modelelement.to_rdf(), format="turtle")
     g2 = Graph().parse(data=src, format="turtle")
 


### PR DESCRIPTION
Her kommer første ordentlige PR på masseskolemiseringen av klassene og properties'ene i modelldcatno. 

Det er laget en liten test også til @matsjs  (test_should_support_three_generations_of_nodes_without_identifier) 

for å vise at nå er det mulig å legge til mer enn 2 generasjoner av noder uten identifier.

Skolemiseringen settes i det øyeblikk man kalles to_rdf() på et eller annet.