### PR TITLE
fix: #105 adding rdflib binding

### DIFF
--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -380,6 +380,7 @@ class InformationModel(Resource):
     def _to_graph(self: InformationModel) -> Graph:
 
         super(InformationModel, self)._to_graph()
+        self._g.bind("modelldcatno", MODELLDCATNO)
 
         self._g.add((URIRef(self.identifier), RDF.type, self._type))
 


### PR DESCRIPTION
Følgende lille besvergelse er utelatt i InformationModel:

```self._g.bind("modelldcatno", MODELLDCATNO)```

Resultatet er at grafen ikke serialiseres med riktig namespace. I stedet skriver rdflib f.eks ns1 som namespace.