### PR TITLE
New properties on dct:Standard - owl:versionInfo, rdfs:seeAlso, dct:title, optional identifier on constructor, subclassing modelldcatno:InformationModell of dct:Standard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "modelldcatnotordf"
-version = "1.0.5"
+version = "1.0.6"
 description= "A library for mapping a modelldcatno model to rdf"
 authors = ["Stig B. Dørmænen <stigbd@gmail.com>", "Frederik Rønnevig <frederik.ronnevig@gmail.com>"]
 license = "Apache-2.0"

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -50,6 +50,11 @@ class Standard:
     _has_reference: str
     _has_version_number: str
 
+    def __init__(self, identifier: Optional[str] = None) -> None:
+        """Inits InformationModel object with default values."""
+        if identifier:
+            self.identifier = identifier
+
     @property
     def identifier(self) -> str:
         """Get for identifier."""

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -32,7 +32,6 @@ import validators
 from modelldcatnotordf.document import FoafDocument
 from modelldcatnotordf.licensedocument import LicenseDocument
 
-
 DCAT = Namespace("http://www.w3.org/ns/dcat#")
 ODRL = Namespace("http://www.w3.org/ns/odrl/2/")
 PROV = Namespace("http://www.w3.org/ns/prov#")
@@ -46,6 +45,7 @@ class Standard:
 
     _g: Graph
     _identifier: URI
+    _title: dict
 
     @property
     def identifier(self) -> str:
@@ -55,6 +55,16 @@ class Standard:
     @identifier.setter
     def identifier(self, identifier: str) -> None:
         self._identifier = URI(identifier)
+
+    @property
+    def title(self) -> dict:
+        """Get for title attribute."""
+        return self._title
+
+    @title.setter
+    def title(self, title: dict) -> None:
+        """Set for title attribute."""
+        self._title = title
 
     def to_rdf(
         self, format: str = "turtle", encoding: Optional[str] = "utf-8"
@@ -85,6 +95,16 @@ class Standard:
         _self = URIRef(self.identifier)
 
         self._g.add((_self, RDF.type, DCTERMS.Standard))
+
+        if getattr(self, "title", None):
+            for key in self.title:
+                self._g.add(
+                    (
+                        URIRef(self.identifier),
+                        DCTERMS.title,
+                        Literal(self.title[key], lang=key),
+                    )
+                )
 
         return self._g
 

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -22,6 +22,7 @@ from rdflib import (
     Namespace,
     OWL,
     RDF,
+    RDFS,
     SKOS,
     URIRef,
     XSD,
@@ -46,6 +47,7 @@ class Standard:
     _g: Graph
     _identifier: URI
     _title: dict
+    _has_reference: str
 
     @property
     def identifier(self) -> str:
@@ -65,6 +67,16 @@ class Standard:
     def title(self, title: dict) -> None:
         """Set for title attribute."""
         self._title = title
+
+    @property
+    def has_reference(self: Standard) -> str:
+        """Get for has_reference."""
+        return self._has_reference
+
+    @has_reference.setter
+    def has_reference(self: Standard, has_reference: str) -> None:
+        """Set for has_reference."""
+        self._has_reference = URI(has_reference)
 
     def to_rdf(
         self, format: str = "turtle", encoding: Optional[str] = "utf-8"
@@ -105,6 +117,11 @@ class Standard:
                         Literal(self.title[key], lang=key),
                     )
                 )
+
+        if getattr(self, "has_reference", None):
+            self._g.add(
+                (URIRef(self.identifier), RDFS.seeAlso, URIRef(self.has_reference))
+            )
 
         return self._g
 

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -48,6 +48,7 @@ class Standard:
     _identifier: URI
     _title: dict
     _has_reference: str
+    _has_version_number: str
 
     @property
     def identifier(self) -> str:
@@ -77,6 +78,16 @@ class Standard:
     def has_reference(self: Standard, has_reference: str) -> None:
         """Set for has_reference."""
         self._has_reference = URI(has_reference)
+
+    @property
+    def has_version_number(self: Standard) -> str:
+        """Get for has_version_number."""
+        return self._has_version_number
+
+    @has_version_number.setter
+    def has_version_number(self: Standard, has_version_number: str) -> None:
+        """Set for has_version_number."""
+        self._has_version_number = has_version_number
 
     def to_rdf(
         self, format: str = "turtle", encoding: Optional[str] = "utf-8"
@@ -121,6 +132,15 @@ class Standard:
         if getattr(self, "has_reference", None):
             self._g.add(
                 (URIRef(self.identifier), RDFS.seeAlso, URIRef(self.has_reference))
+            )
+
+        if getattr(self, "has_version_number", None):
+            self._g.add(
+                (
+                    URIRef(self.identifier),
+                    OWL.versionInfo,
+                    Literal(self.has_version_number),
+                )
             )
 
         return self._g

--- a/src/modelldcatnotordf/modelldcatno.py
+++ b/src/modelldcatnotordf/modelldcatno.py
@@ -44,8 +44,6 @@ ADMS = Namespace("http://www.w3.org/ns/adms#")
 class Standard:
     """A class representing a dct:Standard."""
 
-    __slots__ = ("_g", "_identifier")
-
     _g: Graph
     _identifier: URI
 
@@ -91,7 +89,7 @@ class Standard:
         return self._g
 
 
-class InformationModel(Resource):
+class InformationModel(Resource, Standard):
     """A class representing a modelldatno:InformationModel."""
 
     __slots__ = (

--- a/tests/test_standard.py
+++ b/tests/test_standard.py
@@ -45,6 +45,26 @@ def test_to_graph_should_return_identifier() -> None:
     assert_isomorphic(g1, g2)
 
 
+def test_to_graph_should_return_identifier_set_at_constructor() -> None:
+    """It returns an identifier graph isomorphic to spec."""
+    standard = Standard("http://example.com/standards/1")
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+    <http://example.com/standards/1> a dct:Standard
+    .
+    """
+    g1 = Graph().parse(data=standard.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)
+
+
 def test_to_graph_should_return_standard_skolemization(mocker: MockFixture,) -> None:
     """It returns a standard graph isomorphic to spec."""
     standard = Standard()

--- a/tests/test_standard.py
+++ b/tests/test_standard.py
@@ -118,3 +118,28 @@ def test_to_graph_should_return_format_and_see_also() -> None:
     g2 = Graph().parse(data=src, format="turtle")
 
     assert_isomorphic(g1, g2)
+
+
+def test_to_graph_should_return_has_version_number() -> None:
+    """It returns a information model identifier graph isomorphic to spec."""
+    standard = Standard()
+    standard.identifier = "http://example.com/standards/1"
+    standard.has_version_number = "v0.0.14"
+
+    src = """
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+        <http://example.com/standards/1> a dct:Standard ;
+            owl:versionInfo "v0.0.14" ;
+
+        .
+        """
+    g1 = Graph().parse(data=standard.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)

--- a/tests/test_standard.py
+++ b/tests/test_standard.py
@@ -96,7 +96,7 @@ def test_to_graph_should_return_title() -> None:
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_format_and_see_also() -> None:
+def test_to_graph_should_return_has_reference() -> None:
     """It returns a rdfs:seeAlso graph isomorphic to spec."""
     standard = Standard()
     standard.identifier = "http://example.com/standards/1"
@@ -121,7 +121,7 @@ def test_to_graph_should_return_format_and_see_also() -> None:
 
 
 def test_to_graph_should_return_has_version_number() -> None:
-    """It returns a information model identifier graph isomorphic to spec."""
+    """It returns a dct:Standard identifier graph isomorphic to spec."""
     standard = Standard()
     standard.identifier = "http://example.com/standards/1"
     standard.has_version_number = "v0.0.14"

--- a/tests/test_standard.py
+++ b/tests/test_standard.py
@@ -94,3 +94,27 @@ def test_to_graph_should_return_title() -> None:
     g2 = Graph().parse(data=src, format="turtle")
 
     assert_isomorphic(g1, g2)
+
+
+def test_to_graph_should_return_format_and_see_also() -> None:
+    """It returns a rdfs:seeAlso graph isomorphic to spec."""
+    standard = Standard()
+    standard.identifier = "http://example.com/standards/1"
+    standard.has_reference = "http://example.com/link"
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+    <http://example.com/standards/1> a dct:Standard;
+        rdfs:seeAlso <http://example.com/link>
+    .
+    """
+
+    g1 = Graph().parse(data=standard.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)

--- a/tests/test_standard.py
+++ b/tests/test_standard.py
@@ -71,3 +71,26 @@ def test_to_graph_should_return_standard_skolemization(mocker: MockFixture,) -> 
     g2 = Graph().parse(data=src, format="turtle")
 
     assert_isomorphic(g1, g2)
+
+
+def test_to_graph_should_return_title() -> None:
+    """It returns a title graph isomorphic to spec."""
+    standard = Standard()
+    standard.identifier = "http://example.com/standards/1"
+    standard.title = {"nb": "Tittel 1", "en": "Title 1"}
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
+
+    <http://example.com/standards/1> a dct:Standard ;
+            dct:title   "Title 1"@en, "Tittel 1"@nb ;
+    .
+    """
+    g1 = Graph().parse(data=standard.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    assert_isomorphic(g1, g2)


### PR DESCRIPTION
- feat: #170 owl:versionInfo on dct:Standard
- feat: #170 rdfs:seeAlso on dct:Standard
- feat: #170 dct:title on dct:Standard
- feat: #170 makes modelldcatno:InformationModel a subclass of dct:Standard
- feat: adding optional identifier to constructor on dct:Standard
- chore: bumping project version

Closes #170 