### PR TITLE
Improving examples of use of controlled vocabulary for dct:type

### DIFF
--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -400,7 +400,7 @@ def test_to_graph_should_return_has_data_type_both_identifiers() -> None:
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_has_data_type_bnode_attribute_id(
+def test_to_graph_should_return_has_data_type_skolemized_attribute_id(
     mocker: MockFixture,
 ) -> None:
     """It returns a has_data_type graph isomorphic to spec."""

--- a/tests/test_code_element.py
+++ b/tests/test_code_element.py
@@ -740,7 +740,7 @@ def test_to_graph_should_return_next() -> None:
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_next_bnode() -> None:
+def test_to_graph_should_return_next_skolemized() -> None:
     """It returns an identifier graph isomorphic to spec."""
     codeelement1 = CodeElement()
     codeelement1.identifier = "http://example.com/codeelements/1"
@@ -803,7 +803,7 @@ def test_to_graph_should_return_previous() -> None:
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_previous_bnode() -> None:
+def test_to_graph_should_return_previous_skolemized() -> None:
     """It returns an identifier graph isomorphic to spec."""
     codeelement1 = CodeElement()
     codeelement1.identifier = "http://example.com/codeelements/1"

--- a/tests/test_informationmodel.py
+++ b/tests/test_informationmodel.py
@@ -437,7 +437,7 @@ def test_to_graph_should_return_license_document_skolemization(
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_license_document_bnode_with_types(
+def test_to_graph_should_return_license_document_skolemized_with_types(
     mocker: MockFixture,
 ) -> None:
     """It returns an information model graph isomorphic to spec."""

--- a/tests/test_modelelement.py
+++ b/tests/test_modelelement.py
@@ -159,7 +159,7 @@ def test_to_graph_should_return_has_property_both_identifiers() -> None:
     assert_isomorphic(g1, g2)
 
 
-def test_to_graph_should_return_has_property_bnode_modelelement_id(
+def test_to_graph_should_return_has_property_skolemized_modelelement_id(
     mocker: MockFixture,
 ) -> None:
     """It returns a has_property graph isomorphic to spec."""


### PR DESCRIPTION
- chore: #173 altering example, using controlled vocabulary on dct:type on modelldcatno:InformationModel
- chore: correcting test method description

Closes #173